### PR TITLE
Revise signature of list_snapshots

### DIFF
--- a/UserDocs.md
+++ b/UserDocs.md
@@ -52,8 +52,8 @@ Deletes the object at `path`.
 #### `helium.snapshot(path, message)`
 Creates a snapshot of the T4 object at `path` with commit message `message`.
 
-#### `helium.list_snapshots(path)`
-Lists all snapshots of the T4 object at path. Output consists of path, hash, timestamp, and message.
+#### `helium.list_snapshots(bucket, contains=None)`
+Lists all snapshots in a T4 bucket. Output consists of path, hash, timestamp, and message. `contains` is an optional parameter that limits the results to only snapshots that contain the specified prefix.
 
 #### `helium.diff(srchash, desthash)`
 Lists differences between two T4 objects: one object with snapshot `srchash` , and one object with snapshot `desthash`.

--- a/ocean/helium/api.py
+++ b/ocean/helium/api.py
@@ -192,8 +192,8 @@ def snapshot(path, message):
     return create_snapshot(path, message)
 
 
-def list_snapshots(path):
-    snapshots_list = get_snapshots(path)
+def list_snapshots(bucket, contains=None):
+    snapshots_list = get_snapshots(bucket, contains)
     return DisplayList(snapshots_list, columns=['hash', 'path', 'timestamp', 'message'], index='path')
 
 

--- a/ocean/helium/snapshots.py
+++ b/ocean/helium/snapshots.py
@@ -79,8 +79,7 @@ def read_snapshot_by_hash(bucket, snapshothash):
     return snapshot
 
 
-def get_snapshots(path):
-    bucket, prefix = split_path(path)
+def get_snapshots(bucket, prefix):
     snapshot_files = list_objects(f'{bucket}/{SNAPSHOT_PREFIX}')
 
     snapshots_list = []
@@ -88,7 +87,7 @@ def get_snapshots(path):
         snapshot_file_key = snapshot_rec['Key']
         tophash, snapshotpath = _parse_snapshot_path(snapshot_file_key)
         
-        if prefix.startswith(snapshotpath):
+        if prefix is None or prefix.startswith(snapshotpath):
             snapshotbytes, _ = download_bytes(f'{bucket}/{snapshot_file_key}')
             snapshot = json.loads(snapshotbytes.decode('utf-8'))
             message = snapshot.get('message')


### PR DESCRIPTION
Updated list_snapshots to take separate bucket and path parameters. The path parmeter is now optional and was renamed to `contains` to clarify that only snapshots that contain the path are returned.