### PR TITLE
Fix whole-bucket snapshot diff

### DIFF
--- a/ocean/helium/api.py
+++ b/ocean/helium/api.py
@@ -208,9 +208,9 @@ def diff(bucket, src, dst):
         dst_path = dst_snapshot.get('path', None)
 
     # TODO: Raise exception instead
-    assert src_path or dst_path
+    assert src_path is not None or dst_path is not None
 
-    if src_path:
+    if src_path is not None:
         src_objects = src_snapshot['contents']
     else:
         src_list = list_objects(f"{bucket}/{dst_path}")


### PR DESCRIPTION
Fixing a buggy assertion that checked for truthiness and not is-none and so failed on whole-bucket snapshots where the path is an empty string.