### PR TITLE
config() updated with nicer repr, docs updated

### DIFF
--- a/UserDocs.md
+++ b/UserDocs.md
@@ -91,13 +91,15 @@ If `dest` contains file that `src` does not, that fill will appear as an Add.
 ### Configuration
 
 #### `helium.config()`
-Returns an `ordereddict` with the current T4 client configuration details. Configuration is saved to disk.
-
-#### `helium.config(KEY=VALUE [, KEY2=VALUE2, ...])`
-Manually sets a specific configuration option.
+Returns the currenct configuration details as an `ordereddict` subclass, `HeliumConfig`.
+`HeliumConfig` has a cleaner appearance, and includes the file path.
 
 #### `helium.config(URL)`
-Set a configuration option from the URL of a T4 deployment.
+Set the local configuration from the URL of a T4 instance.  Overwrites all local config 
+values if successful, but keeps a backup in the config dir.
+
+#### `helium.config(KEY=VALUE [, KEY2=VALUE2, ...])`
+Manually sets specific configuration options.
 
 ### Navigation
 

--- a/UserDocs.md
+++ b/UserDocs.md
@@ -91,7 +91,7 @@ If `dest` contains file that `src` does not, that fill will appear as an Add.
 ### Configuration
 
 #### `helium.config()`
-Returns the currenct configuration details as an `ordereddict` subclass, `HeliumConfig`.
+Returns the current configuration details as an `ordereddict` subclass, `HeliumConfig`.
 `HeliumConfig` has a cleaner appearance, and includes the file path.
 
 #### `helium.config(URL)`

--- a/ocean/helium/api.py
+++ b/ocean/helium/api.py
@@ -17,8 +17,8 @@ from .data_transfer import (download_bytes, download_file, upload_bytes, upload_
 from .snapshots import (create_snapshot, download_bytes_from_snapshot,
                         download_file_from_snapshot, read_snapshot_by_hash,
                         get_snapshots)
-from .util import (HeliumException, AWS_SEPARATOR, CONFIG_PATH, CONFIG_TEMPLATE, read_yaml,
-                   split_path, validate_url, write_yaml, yaml_has_comments)
+from .util import (HeliumConfig, HeliumException, AWS_SEPARATOR, CONFIG_PATH, CONFIG_TEMPLATE,
+                   read_yaml, split_path, validate_url, write_yaml, yaml_has_comments)
 
 
 class TargetType(Enum):
@@ -388,6 +388,7 @@ def config(*autoconfig_url, **config_values):
 
     :param autoconfig_url: URL indicating a location to configure from
     :param **config_values: `key=value` pairs to set in the config
+    :returns: HeliumConfig object (an ordered Mapping)
     """
     if autoconfig_url and config_values:
         raise HeliumException("Expected either an auto-config URL or key=value pairs, but got both.")
@@ -397,11 +398,11 @@ def config(*autoconfig_url, **config_values):
 
     config_template = read_yaml(CONFIG_TEMPLATE)
     if autoconfig_url:
-        autoconfig_url = autoconfig_url[0].rstrip('/')
-        if not autoconfig_url[:7].lower() in ('http://', 'https:/'):
-            autoconfig_url = 'https://' + autoconfig_url
-        config_template['navigator_url'] = autoconfig_url  # set the provided navigator URL
-        config_url = autoconfig_url + '/config.json'
+        autoconfig_url = autoconfig_url[0]
+        config_url = autoconfig_url.rstrip('/') + '/config.json'
+
+        if config_url[:7] not in ('http://', 'https:/'):
+            config_url = 'https://' + config_url
 
         validate_url(config_url)
 
@@ -427,13 +428,13 @@ def config(*autoconfig_url, **config_values):
             for key in set(config_template) - set(new_config):
                 new_config[key] = config_template[key]
             write_yaml(new_config, CONFIG_PATH, keep_backup=True)
-            return new_config
+            return HeliumConfig(CONFIG_PATH, new_config)
         # Use our config + their configured values, keeping our comments.
         else:
             for key, value in new_config.items():
                 config_template[key] = value
             write_yaml(config_template, CONFIG_PATH, keep_backup=True)
-            return config_template
+            return HeliumConfig(CONFIG_PATH, config_template)
     # No autoconfig URL given -- use local config
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
@@ -448,4 +449,4 @@ def config(*autoconfig_url, **config_values):
             validate_url(value)
         local_config[key] = value
     write_yaml(local_config, CONFIG_PATH, keep_backup=True)
-    return local_config
+    return HeliumConfig(CONFIG_PATH, local_config)

--- a/ocean/helium/util.py
+++ b/ocean/helium/util.py
@@ -1,5 +1,6 @@
 from collections import Mapping, Sequence, Set
 import datetime
+import json
 import os
 
 # backports
@@ -152,3 +153,18 @@ def validate_url(url):
         parsed_url.port
     except ValueError:
         raise HeliumException("Invalid URL -- Port must be a number: {}".format(url))
+
+
+# Although displaying the config may seem not to warrant a class, it's pretty important
+# for good UX. A lot of points were considered in making this -- retaining order,
+# user's usage in an interpreted environment like Jupyter, and keeping the displayed
+# information concise.  Given the limitations of the other options, making a class with
+# custom repr panned out to be the best (and shortest) option.
+class HeliumConfig(OrderedDict):
+    def __init__(self, filepath, *args, **kwargs):
+        self.filepath = pathlib.Path(filepath)
+        super(HeliumConfig, self).__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return "<{} at {!r} {}>".format(type(self).__name__, str(self.filepath), json.dumps(self, indent=4))
+


### PR DESCRIPTION
This is a very lightweight class used for interpreter display when a user calls `he.config()`.  This is similar in spirit to our `DisplayList`, but doesn't require usage of HTML.

Quite a few options were considered, but a lightweight class made the most sense -- we want to retain order, and we want to display the filename.

* returning a tuple is obscure and breaks consistency
* returning a namedtuple breaks consistency, and the contained config doesn't display nicely
* returning an OrderedDict is just ugly, and doesn't include the filename
* returning a regular dict displays fine, but loses order and doesn't include the filename
