### PR TITLE
Make the QuickStart more reproducible

### DIFF
--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "# The local folder that will act as scratch space for some files we\n",
     "# will create in this notebook.\n",
+    "# This path must end in a forward slash (\"/\").\n",
     "local_folder  = \"./\"\n",
     "\n",
     "# A date timestamp that will be included in the output path for files\n",
@@ -347,9 +348,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`helium` lets you read and write Python objects with `put()`. `put()` accepts an optional `metadata=` keyword. Use `metadata=` to annotate objects. T4 indexes all metadata so that you can find specific objects or files with `search()`.\n",
-    "\n",
-    "In the example below are are working with an S3 bucket called `alpha-quilt-storage`. To write to your own"
+    "`helium` lets you read and write Python objects with `put()`. `put()` accepts an optional `metadata=` keyword. Use `metadata=` to annotate objects. T4 indexes all metadata so that you can find specific objects or files with `search()`."
    ]
   },
   {

--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -521,9 +521,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the future, T4 sill offer other ways of accessing version information more directly.\n",
+    "In the future, T4 will offer other ways of accessing version information more directly.\n",
     "\n",
-    "To grab a specific object version ,use the optional `version=` keyword to `get()` or `get_file()`:"
+    "To grab a specific object version, use the optional `version=` keyword to `get()` or `get_file()`:"
    ]
   },
   {
@@ -964,12 +964,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
     "local_repo      = local_folder + \"hurdat-example-repo\"\n",
-    "local_data_copy = local_folder + \"atlantic.csv\""
+    "local_data_copy = local_folder + \"atlantic-storms.csv\""
    ]
   },
   {

--- a/notebooks/QuickStart.ipynb
+++ b/notebooks/QuickStart.ipynb
@@ -5,15 +5,47 @@
    "metadata": {},
    "source": [
     "## Installation\n",
-    "[Install the T4 Python client](https://github.com/quiltdata/t4/blob/master/UserDocs.md), `helium`.\n",
+    "[Install the T4 Python client](https://github.com/quiltdata/t4/blob/master/UserDocs.md), `helium`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The name of the bucket you will run this demo against. This must be \n",
+    "# an S3 bucket you have access to.\n",
+    "bucket_name   = \"alpha-quilt-storage\"\n",
     "\n",
+    "# The subfolder inside of the bucket that this demo will be placed in.\n",
+    "bucket_folder = \"hurdat-demo\"\n",
+    "\n",
+    "# The local folder that will act as scratch space for some files we\n",
+    "# will create in this notebook.\n",
+    "local_folder  = \"./\"\n",
+    "\n",
+    "# A date timestamp that will be included in the output path for files\n",
+    "# pushed to S3 by this notebook. Helps ensure tidyness.\n",
+    "from datetime import datetime\n",
+    "bucket_subfolder = str(datetime.now())\\\n",
+    "    .replace(\" \", \"-\").replace(\":\", \"_\").replace(\".\", \"_\")\n",
+    "\n",
+    "# Resulting path.\n",
+    "t4_path = f'{bucket_name}/{bucket_folder}/{bucket_subfolder}/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Intro\n",
     "This notebook offers a five-minute tour of the T4 Python API, codename `helium`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -22,9 +54,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/karve/anaconda3/envs/dev/lib/python3.6/site-packages/requests/__init__.py:80: RequestsDependencyWarning: urllib3 (1.23) or chardet (3.0.4) doesn't match a supported version!\n",
-      "  RequestsDependencyWarning)\n",
-      "/Users/karve/anaconda3/envs/dev/lib/python3.6/site-packages/tqdm/autonotebook/__init__.py:14: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "/Users/alex/miniconda3/envs/quilt-dev/lib/python3.6/site-packages/tqdm/autonotebook/__init__.py:14: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  \" (e.g. in jupyter console)\", TqdmExperimentalWarning)\n"
      ]
     }
@@ -48,11 +78,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load hurdat/build.py\n"
+    "%load hurdat/build.py"
    ]
   },
   {
@@ -64,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -297,7 +327,7 @@
        "[5 rows x 21 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,11 +354,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "he.put(atlantic_storms, \"alpha-quilt-storage/~aleksey/hurdat/atlantic-storms-data.parquet\",\n",
+    "he.put(atlantic_storms, t4_path + \"atlantic-storms-data.parquet\",\n",
     "       meta={'source': 'https://www.nhc.noaa.gov/data/hurdat/hurdat2-1851-2017-050118.txt', \n",
     "             'ocean': 'atlantic'})"
    ]
@@ -342,26 +372,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "atlantic_storms, meta = he.get(\"alpha-quilt-storage/~aleksey/hurdat/atlantic-storms-data.parquet\")"
+    "atlantic_storms, meta = he.get(t4_path + \"atlantic-storms-data.parquet\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ocean': 'atlantic',\n",
-       " 'source': 'https://www.nhc.noaa.gov/data/hurdat/hurdat2-1851-2017-050118.txt'}"
+       "{'source': 'https://www.nhc.noaa.gov/data/hurdat/hurdat2-1851-2017-050118.txt',\n",
+       " 'ocean': 'atlantic'}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -381,29 +411,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fn = \"~/Desktop/atlantic-storms.csv\"\n",
-    "atlantic_storms.to_csv(fn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "atlantic-storms.csv\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "%ls ~/Desktop | grep 'atlantic'"
+    "local_filepath = f\"{local_folder}atlantic-storms.csv\"\n",
+    "atlantic_storms.to_csv(local_filepath)"
    ]
   },
   {
@@ -412,9 +425,26 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./atlantic-storms.csv\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "%ls $local_filepath | grep 'atlantic'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "96e307472d744bdfba46ccdd9afbf8a7",
+       "model_id": "148096cdfcba4990a718c7cf093840b6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -434,7 +464,7 @@
     }
    ],
    "source": [
-    "he.put_file(\"/Users/alex/Desktop/atlantic-storms.csv\", \"alpha-quilt-storage/~aleksey/hurdat/atlantic-storms-data.csv\")"
+    "he.put_file(local_filepath, t4_path + \"atlantic-storms-data.csv\")"
    ]
   },
   {
@@ -452,48 +482,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'ETag': '\"7d9faecef6a675b04246fda5d2747a7f\"',\n",
-       "  'IsLatest': False,\n",
-       "  'Key': '~aleksey/hurdat/',\n",
-       "  'LastModified': datetime.datetime(2018, 10, 4, 21, 13, 14, tzinfo=tzutc()),\n",
-       "  'Owner': {'DisplayName': 'kmoore',\n",
-       "   'ID': '1e740c9f01d3eb40d580b51a943de9c75ba2af0c2f75e1ac7b021cd7afd1872a'},\n",
-       "  'Size': 40,\n",
+       "[{'ETag': '\"701df1515152860cf2a7a8498133ca82\"',\n",
+       "  'Size': 3871481,\n",
        "  'StorageClass': 'STANDARD',\n",
-       "  'VersionId': 'jwSyCWiv_zL5Lg.sOyN1RMMQCnGzk.0O'},\n",
-       " {'ETag': '\"7d9faecef6a675b04246fda5d2747a7f\"',\n",
-       "  'IsLatest': False,\n",
-       "  'Key': '~aleksey/hurdat/',\n",
-       "  'LastModified': datetime.datetime(2018, 10, 4, 21, 11, 41, tzinfo=tzutc()),\n",
+       "  'Key': 'hurdat-demo/2018-10-11-13_22_16_617100/atlantic-storms-data.csv',\n",
+       "  'VersionId': 's9.iEupWjhaaT7lg1JcRNqK_D3ms8R3M',\n",
+       "  'IsLatest': True,\n",
+       "  'LastModified': datetime.datetime(2018, 10, 11, 20, 22, 54, tzinfo=tzutc()),\n",
        "  'Owner': {'DisplayName': 'kmoore',\n",
-       "   'ID': '1e740c9f01d3eb40d580b51a943de9c75ba2af0c2f75e1ac7b021cd7afd1872a'},\n",
-       "  'Size': 40,\n",
+       "   'ID': '1e740c9f01d3eb40d580b51a943de9c75ba2af0c2f75e1ac7b021cd7afd1872a'}},\n",
+       " {'ETag': '\"502f21cfc143fb0c35f563eda5699fa9\"',\n",
+       "  'Size': 923078,\n",
        "  'StorageClass': 'STANDARD',\n",
-       "  'VersionId': 'HvmCd4AGwG4Og3mwGxQMfPDWiZhmtII3'},\n",
-       " {'ETag': '\"7d9faecef6a675b04246fda5d2747a7f\"',\n",
-       "  'IsLatest': False,\n",
-       "  'Key': '~aleksey/hurdat/',\n",
-       "  'LastModified': datetime.datetime(2018, 10, 4, 21, 9, 53, tzinfo=tzutc()),\n",
+       "  'Key': 'hurdat-demo/2018-10-11-13_22_16_617100/atlantic-storms-data.parquet',\n",
+       "  'VersionId': 'IY3CMAr6G7TtEoG30kR2QHsvEyxz.HjK',\n",
+       "  'IsLatest': True,\n",
+       "  'LastModified': datetime.datetime(2018, 10, 11, 20, 22, 37, tzinfo=tzutc()),\n",
        "  'Owner': {'DisplayName': 'kmoore',\n",
-       "   'ID': '1e740c9f01d3eb40d580b51a943de9c75ba2af0c2f75e1ac7b021cd7afd1872a'},\n",
-       "  'Size': 40,\n",
-       "  'StorageClass': 'STANDARD',\n",
-       "  'VersionId': 'iUxtMYQh.Z3mInIaitovWpdEP3XY9DKb'}]"
+       "   'ID': '1e740c9f01d3eb40d580b51a943de9c75ba2af0c2f75e1ac7b021cd7afd1872a'}}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "he.ls(\"alpha-quilt-storage/~aleksey/hurdat\")[1][:3]"
+    "he.ls(t4_path)[1][:3]"
    ]
   },
   {
@@ -507,12 +528,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "data, meta = he.get(\"alpha-quilt-storage/~aleksey/hurdat/atlantic-storms.parquet\", \n",
-    "                    version=\"mP4USSZF2mJSaKNvr7EjUldDQm3Sqb_b\")"
+    "# Select and specify the version from the output above.\n",
+    "data, meta = he.get(t4_path + \"atlantic-storms-data.parquet\", \n",
+    "                    version=\"IY3CMAr6G7TtEoG30kR2QHsvEyxz.HjK\")"
    ]
   },
   {
@@ -542,22 +564,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'724cde9ad4688727ce886b5ece405103c3cb152d7ac076c88d2bf2cd254a1e66'"
+       "'17b3c6dea9937dfef9123ef371d927bb3939b6493d49f15ecbdbe3512ac35e40'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "he.snapshot(\"alpha-quilt-storage/~aleksey/hurdat/\", message=\"Third cut at cleaning up HURDAT\")"
+    "he.snapshot(t4_path, message=\"Initial snapshot\")"
    ]
   },
   {
@@ -569,10 +591,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -594,10 +614,10 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>~aleksey/hurdat/</th>\n",
-       "      <td>724cde9ad4688727ce886b5ece405103c3cb152d7ac076...</td>\n",
-       "      <td>2018-10-09 23:09:19+00:00</td>\n",
-       "      <td>Third cut at cleaning up HURDAT</td>\n",
+       "      <th>hurdat-demo/2018-10-11-13_22_16_617100/</th>\n",
+       "      <td>17b3c6dea9937dfef9123ef371d927bb3939b6493d49f1...</td>\n",
+       "      <td>2018-10-11 20:24:00+00:00</td>\n",
+       "      <td>Initial snapshot</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th></th>\n",
@@ -606,75 +626,41 @@
        "      <td>foo2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>~aleksey/</th>\n",
-       "      <td>5460a76611597d3cf53ea4b0acb8d9695261523ac04de5...</td>\n",
-       "      <td>2018-10-08 22:26:16+00:00</td>\n",
-       "      <td>foo2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>~aleksey/</th>\n",
-       "      <td>9aa46097e10cb7b22a6667ac4bb7b6329b2411240936aa...</td>\n",
-       "      <td>2018-10-08 22:01:13+00:00</td>\n",
-       "      <td>foo</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th></th>\n",
        "      <td>435d7b954fe6dbd35cf51b311971fc49643d24af9f6f69...</td>\n",
        "      <td>2018-10-08 21:21:01+00:00</td>\n",
        "      <td>foo</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>~aleksey/hurdat/</th>\n",
-       "      <td>7b1e211f91ac3242748c1423525f7d6e846914c055a6c5...</td>\n",
-       "      <td>2018-10-05 00:36:20+00:00</td>\n",
-       "      <td>Temporary message.</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "[{'hash': '724cde9ad4688727ce886b5ece405103c3cb152d7ac076c88d2bf2cd254a1e66',\n",
-       "  'message': 'Third cut at cleaning up HURDAT',\n",
-       "  'path': '~aleksey/hurdat/',\n",
-       "  'timestamp': datetime.datetime(2018, 10, 9, 23, 9, 19, tzinfo=tzutc())},\n",
+       "[{'hash': '17b3c6dea9937dfef9123ef371d927bb3939b6493d49f15ecbdbe3512ac35e40',\n",
+       "  'path': 'hurdat-demo/2018-10-11-13_22_16_617100/',\n",
+       "  'message': 'Initial snapshot',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 11, 20, 24, tzinfo=tzutc())},\n",
        " {'hash': 'ad9f3e3d938da7fbc5624245fbcb72f5bc25c2dfe4f9af7af7f865d6d7177e98',\n",
-       "  'message': 'foo2',\n",
        "  'path': '',\n",
+       "  'message': 'foo2',\n",
        "  'timestamp': datetime.datetime(2018, 10, 8, 22, 26, 29, tzinfo=tzutc())},\n",
-       " {'hash': '5460a76611597d3cf53ea4b0acb8d9695261523ac04de5859991fbe1c0adf24e',\n",
-       "  'message': 'foo2',\n",
-       "  'path': '~aleksey/',\n",
-       "  'timestamp': datetime.datetime(2018, 10, 8, 22, 26, 16, tzinfo=tzutc())},\n",
-       " {'hash': '9aa46097e10cb7b22a6667ac4bb7b6329b2411240936aa7aee22123429807c14',\n",
-       "  'message': 'foo',\n",
-       "  'path': '~aleksey/',\n",
-       "  'timestamp': datetime.datetime(2018, 10, 8, 22, 1, 13, tzinfo=tzutc())},\n",
        " {'hash': '435d7b954fe6dbd35cf51b311971fc49643d24af9f6f698544f87d7e24ebe83c',\n",
-       "  'message': 'foo',\n",
        "  'path': '',\n",
-       "  'timestamp': datetime.datetime(2018, 10, 8, 21, 21, 1, tzinfo=tzutc())},\n",
-       " {'hash': '7b1e211f91ac3242748c1423525f7d6e846914c055a6c5b4c2d899fd9d0e1f2f',\n",
-       "  'message': 'Temporary message.',\n",
-       "  'path': '~aleksey/hurdat/',\n",
-       "  'timestamp': datetime.datetime(2018, 10, 5, 0, 36, 20, tzinfo=tzutc())}]"
+       "  'message': 'foo',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 8, 21, 21, 1, tzinfo=tzutc())}]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "he.list_snapshots(\"alpha-quilt-storage/~aleksey/hurdat/\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "he.put({\"description\": \"A simple JSON file\"}, \"alpha-quilt-storage/~aleksey/hurdat/simple.json\")"
+    "he.list_snapshots(\n",
+    "    bucket_name, \n",
+    "\n",
+    "    # e.g. 'hurdat-demo/2018-10-11-11_53_37_098339/'\n",
+    "    contains=f'{bucket_folder}/{bucket_subfolder}/'\n",
+    ")"
    ]
   },
   {
@@ -686,7 +672,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "he.put({\"description\": \"A simple JSON file\"}, \n",
+    "       t4_path + \"simple.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -708,25 +704,26 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>Added</th>\n",
-       "      <td>~aleksey/hurdat/simple.json</td>\n",
+       "      <td>hurdat-demo/2018-10-11-13_22_16_617100/simple....</td>\n",
        "      <td>\"725f0cda0939ef902a1cb9bcb89923cd\"</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
       ],
       "text/plain": [
-       "[{'ETag': '\"725f0cda0939ef902a1cb9bcb89923cd\"',\n",
-       "  'Key': '~aleksey/hurdat/simple.json',\n",
+       "[{'Key': 'hurdat-demo/2018-10-11-13_22_16_617100/simple.json',\n",
+       "  'ETag': '\"725f0cda0939ef902a1cb9bcb89923cd\"',\n",
        "  'status': 'Added'}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "he.diff(\"alpha-quilt-storage\", \"724cde9ad46\", \"latest\")"
+    "# Select and specify the snapshot from the output above.\n",
+    "he.diff(bucket_name, \"17b3c6d\", \"latest\")"
    ]
   },
   {
@@ -746,11 +743,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cloning into 'hurdat-example-repo'...\n",
+      "remote: Enumerating objects: 12, done.\u001b[K\n",
+      "remote: Counting objects: 100% (12/12), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (8/8), done.\u001b[K\n",
+      "remote: Total 12 (delta 0), reused 12 (delta 0), pack-reused 0\u001b[K\n",
+      "Unpacking objects: 100% (12/12), done.\n"
+     ]
+    }
+   ],
    "source": [
-    "!cd ~/Desktop; git clone https://github.com/ResidentMario/hurdat-example-repo"
+    "!cd $local_folder; git clone https://github.com/ResidentMario/hurdat-example-repo"
    ]
   },
   {
@@ -764,31 +774,136 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1d62535aaf6f400eae7487f0bf5eca27",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=3758670), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "# Note: replace this path with one that works on your local machine.\n",
-    "he.put_file(\"/Users/alex/Desktop/hurdat-example-repo/data/\", \n",
-    "            \"alpha-quilt-storage/aleksey/hurdat-example-repo/data/\")"
+    "he.put_file(\n",
+    "    local_folder + \"hurdat-example-repo/data/\",\n",
+    "    t4_path + \"data/\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'61cc385ebfdb5eba5f005605742ebba6cdda4034169809130e38ac73c7da5de3'"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "he.snapshot(\"alpha-quilt-storage/aleksey/hurdat-example-repo/data/\", message=\"Snap.\")"
+    "he.snapshot(t4_path + \"data/\", message=\"Snap.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hash</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>message</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>path</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>hurdat-demo/2018-10-11-13_22_16_617100/data/</th>\n",
+       "      <td>61cc385ebfdb5eba5f005605742ebba6cdda4034169809...</td>\n",
+       "      <td>2018-10-11 20:24:35+00:00</td>\n",
+       "      <td>Snap.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>hurdat-demo/2018-10-11-13_22_16_617100/</th>\n",
+       "      <td>17b3c6dea9937dfef9123ef371d927bb3939b6493d49f1...</td>\n",
+       "      <td>2018-10-11 20:24:00+00:00</td>\n",
+       "      <td>Initial snapshot</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>ad9f3e3d938da7fbc5624245fbcb72f5bc25c2dfe4f9af...</td>\n",
+       "      <td>2018-10-08 22:26:29+00:00</td>\n",
+       "      <td>foo2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <td>435d7b954fe6dbd35cf51b311971fc49643d24af9f6f69...</td>\n",
+       "      <td>2018-10-08 21:21:01+00:00</td>\n",
+       "      <td>foo</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "[{'hash': '61cc385ebfdb5eba5f005605742ebba6cdda4034169809130e38ac73c7da5de3',\n",
+       "  'path': 'hurdat-demo/2018-10-11-13_22_16_617100/data/',\n",
+       "  'message': 'Snap.',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 11, 20, 24, 35, tzinfo=tzutc())},\n",
+       " {'hash': '17b3c6dea9937dfef9123ef371d927bb3939b6493d49f15ecbdbe3512ac35e40',\n",
+       "  'path': 'hurdat-demo/2018-10-11-13_22_16_617100/',\n",
+       "  'message': 'Initial snapshot',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 11, 20, 24, tzinfo=tzutc())},\n",
+       " {'hash': 'ad9f3e3d938da7fbc5624245fbcb72f5bc25c2dfe4f9af7af7f865d6d7177e98',\n",
+       "  'path': '',\n",
+       "  'message': 'foo2',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 8, 22, 26, 29, tzinfo=tzutc())},\n",
+       " {'hash': '435d7b954fe6dbd35cf51b311971fc49643d24af9f6f698544f87d7e24ebe83c',\n",
+       "  'path': '',\n",
+       "  'message': 'foo',\n",
+       "  'timestamp': datetime.datetime(2018, 10, 8, 21, 21, 1, tzinfo=tzutc())}]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "he.list_snapshots(\"alpha-quilt-storage/aleksey/hurdat-example-repo/data/\")"
+    "he.list_snapshots(bucket_name, \n",
+    "                  contains=f'{bucket_folder}/{bucket_subfolder}/data/')"
    ]
   },
   {
@@ -800,14 +915,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6968d04415dd469991d637d3928aacdc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(IntProgress(value=0, max=3758670), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "# Note: replace this path with one that works on your local machine.\n",
-    "he.get_file(\"alpha-quilt-storage/aleksey/hurdat-example-repo/data/atlantic.csv\", \n",
-    "            \"/Users/alex/Desktop/hurdat-example-repo/data/atlantic.csv\",\n",
-    "            snapshot=\"cb06134062b8b8\")"
+    "he.get_file(t4_path + \"data/atlantic.csv\", \n",
+    "            local_folder + \"atlantic.csv\",\n",
+    "            snapshot=\"61cc38\")"
    ]
   },
   {
@@ -828,13 +964,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clean up\n",
-    "!rm -rf ~/Desktop/hurdat-example-repo\n",
-    "!rm ~/Desktop/atlantic-storms.csv"
+    "local_repo      = local_folder + \"hurdat-example-repo\"\n",
+    "local_data_copy = local_folder + \"atlantic.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf $local_repo\n",
+    "!rm $local_data_copy"
    ]
   }
  ],
@@ -854,7 +999,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In this PR I pull most of the hardcoded paths out to configuration variables that the user sets at the start of the notebook. I've also fixed the possibility of a notebook collisions by working out of a folder parameterized with `datetime.now`.

You still need to perform some copy-pasta by hand to run it (e.g. you can't just click Run All and expect it to work), in particular in the cells parameterizing snapshot and version IDs.