### PR TITLE
Implement local metadata using xattrs

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -42,6 +42,7 @@ setup(
         'ruamel.yaml<=0.15.70',
         'six>=1.10.0',
         'tqdm>=4.26.0',
+        'xattr>=0.9.6',
     ],
     extras_require={
         'tests': [

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -42,7 +42,7 @@ setup(
         'ruamel.yaml<=0.15.70',
         'six>=1.10.0',
         'tqdm>=4.26.0',
-        'xattr>=0.9.6',
+        'xattr>=0.9.6; platform_system!="Windows"',
     ],
     extras_require={
         'tests': [

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -16,7 +16,7 @@ from .util import (HeliumConfig, HeliumException, AWS_SEPARATOR, CONFIG_PATH,
                    write_yaml, yaml_has_comments)
 
 
-def copy(src, dest, meta=None):
+def copy(src, dest):
     """
     Copies ``src`` object from T4 to ``dest``
 
@@ -26,12 +26,8 @@ def copy(src, dest, meta=None):
     Parameters:
         src (str): a path to retrieve
         dest (str): a path to write to
-        meta (dict): optional metadata that will be assigned to the object
     """
-    all_meta = dict(
-        user_meta=meta
-    )
-    copy_file(fix_url(src), fix_url(dest), all_meta)
+    copy_file(fix_url(src), fix_url(dest))
 
 
 def put(obj, dest, meta=None):

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -34,7 +34,6 @@ def _get_object(self, **kwargs):
     return resp
 s3_client.get_object = type(_old_get_object)(_get_object, s3_client)
 
-s3_manager = create_transfer_manager(s3_client, TransferConfig())
 s3_manager.ALLOWED_DOWNLOAD_ARGS = s3_manager.ALLOWED_DOWNLOAD_ARGS + ['Callback']
 
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -25,6 +25,10 @@ s3_client = boto3.client('s3')
 s3_transfer_config = TransferConfig()
 s3_manager = create_transfer_manager(s3_client, s3_transfer_config)
 
+# s3transfer does not give us a way to access the metadata of an object it's downloading,
+# even though it has access to it. To get around this, we patch the s3 client to get a callback
+# with the response.
+# See https://github.com/boto/s3transfer/issues/104
 _old_get_object = s3_client.get_object
 def _get_object(self, **kwargs):
     callback = kwargs.pop('Callback', None)

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -3,6 +3,7 @@ from enum import Enum
 import hashlib
 import json
 import pathlib
+import platform
 import shutil
 from threading import Lock
 from urllib.parse import urlparse
@@ -13,13 +14,17 @@ from boto3.s3.transfer import TransferConfig, create_transfer_manager
 from s3transfer.subscribers import BaseSubscriber
 from six import BytesIO, binary_type, text_type
 from tqdm.autonotebook import tqdm
-import xattr
 
 from .util import HeliumException, split_path, parse_file_url, parse_s3_url
+from . import xattr
 
 
 HELIUM_METADATA = 'helium'
-HELIUM_XATTR = 'user.com.quiltdata.helium'
+HELIUM_XATTR = 'com.quiltdata.helium'
+
+if platform.system() == 'Linux':
+    # Linux only allows users to modify user.* xattrs.
+    HELIUM_XATTR = 'user.%s' % HELIUM_XATTR
 
 s3_client = boto3.client('s3')
 s3_transfer_config = TransferConfig()

--- a/api/python/t4/xattr.py
+++ b/api/python/t4/xattr.py
@@ -1,0 +1,29 @@
+"""
+Wraps `xattr` and adds a basic Windows implementation.
+"""
+
+import platform
+
+if platform.system() != 'Windows':
+    from xattr import getxattr, setxattr, removexattr
+else:
+    import os
+
+    def _get_stream_path(filename, stream):
+        # Because Windows is awesome:
+        # https://docs.microsoft.com/en-us/windows/desktop/fileio/file-streams#naming-conventions-for-streams
+        if len(str(filename)) == 1:
+            filename = '.\\%s' % filename
+
+        return '%s:%s' % (filename, stream)
+
+    def getxattr(filename, name, symlink=False):
+        with open(_get_stream_path(filename, name), 'rb') as fd:
+            return fd.read()
+
+    def setxattr(filename, name, value, options=0, symlink=False):
+        with open(_get_stream_path(filename, name), 'wb') as fd:
+            fd.write(value)
+
+    def removexattr(filename, name, symlink=False):
+        os.remove(_get_stream_path(filename, name))


### PR DESCRIPTION
xattrs are easy. Extracting metadata from the s3 transfer manager, on the other hand...
We could just make an extra HEAD request for each file - but that's inefficient. Instead, we can just patch the s3 client.