### PR TITLE
Pytest: Allow mock before load of modules

### DIFF
--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -17,41 +17,62 @@ import pytest
 
 
 # Module Vars / Constants
-class _Vars():
-    temp_dir = None
-    base_dir = None
-    base_path = None
-    config_path = None
+class Vars:
+    tmpdir_factory = None
+    tmpdir_home = None
+    tmpdir_data = None
+    extrasession_mockers = []
 
-vars = _Vars()
+
+def pytest_sessionstart(session):
+    """ pytest_sessionstart hook
+
+    This runs *before* import and collection of tests.
+
+    This is *THE* place to do mocking of things that are global,
+    such as `appdirs`.
+
+    Do teardown in `pytest_sessionfinish()`
+    """
+    print("Pre-Session Setup..")
+    # Figuring out how to use the pytest tmpdir fixture externally was kinda awful.
+    Vars.tmpdir_home = pytest.ensuretemp('fake_home')
+    Vars.tmpdir_data = Vars.tmpdir_home.mkdir('appdirs_datadir')
+
+    user_data_dir = lambda *x: Vars.tmpdir_data / x[0] if x else Vars.tmpdir_data
+
+    # Mockers that need to be loaded before any of our code
+    Vars.extrasession_mockers.extend([
+        mock.patch('appdirs.user_data_dir', user_data_dir)
+    ])
+
+    for mocker in Vars.extrasession_mockers:
+        mocker.start()
+
+    print("appdirs.user_data_dir mocked to produce {!r}".format(user_data_dir()))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """ pytest_sessionfinish hook
+
+    This runs *after* any finalizers or other session activities.
+
+    Performs teardown for `pytest_sessionstart()`
+    """
+    print("\nPost-session Teardown..")
+
+    for mocker in Vars.extrasession_mockers:
+        mocker.stop()
+
 
 # scope: function, class, module, or session
 # autouse: boolean.  Apply to all instances of the given scope.
 @pytest.fixture(scope='session', autouse=True)
-def each_session(request, tmpdir_factory):
+def each_session(request):
     print("\nSetup session..")
-
-    if vars.temp_dir is None:
-        # returns a.. ..py.path.local?  non-standard path library, inherits str.
-        vars.temp_dir = tmpdir_factory.mktemp('test_home')
-    vars.base_dir = vars.temp_dir.mkdir('helium_base')
-    vars.base_path = Path(vars.base_dir)
-    vars.config_path = vars.base_path / 'config.yml'
-
-    mockers = [
-        mock.patch('t4.util.BASE_DIR', vars.base_dir),
-        mock.patch('t4.util.BASE_PATH', vars.base_path),
-        mock.patch('t4.util.CONFIG_PATH', vars.config_path),
-        mock.patch('t4.api.CONFIG_PATH', vars.config_path),
-        ]
-    for mocker in mockers:
-        mocker.start()
 
     def teardown():  # can be named whatever
         print("\nTeardown session..")
-        # Not super-necessary, as this is session-scoped, but let's clean up anyways..
-        for mocker in mockers:
-            mocker.stop()
 
     request.addfinalizer(teardown)
 

--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -49,8 +49,6 @@ def pytest_sessionstart(session):
     for mocker in Vars.extrasession_mockers:
         mocker.start()
 
-    print("appdirs.user_data_dir mocked to produce {!r}".format(user_data_dir()))
-
 
 def pytest_sessionfinish(session, exitstatus):
     """ pytest_sessionfinish hook


### PR DESCRIPTION
In pytest, typically all configuration is done in a session, or as part of a session.  However, even with a fixture with `scope='session'`, our tests have already been loaded, and thus our modules have been loaded.

This is problematic with configuration based on environment, such as with `appdirs`, where more than one 'constant' has already been set by the time any function in `appdirs` can be mocked.

This PR creates an area in `conftest.py` where you can perform actions before and after the session scope is executed.