### PR TITLE
Unset top_hash when returning modified package

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -262,6 +262,8 @@ class Package(object):
             logical_key = prefix + f.relative_to(src_path).as_posix()
             # TODO: Warn if overwritting a logical key?
             pkg = pkg.set(logical_key, entry)
+
+        pkg._unset_tophash()
         return pkg
 
     def get(self, logical_key):
@@ -402,6 +404,7 @@ class Package(object):
         pkg = self._clone()
         for logical_key, entry in new_keys_dict.items():
             pkg = pkg.set(logical_key, entry, meta)
+        pkg._unset_tophash()
         return pkg
 
     def set(self, logical_key, entry=None, meta=None):
@@ -438,11 +441,13 @@ class Package(object):
                 raise PackageException("Must specify metadata in the entry")
         else:
             raise NotImplementedError
+        pkg._unset_tophash()
         return pkg
 
     def _update_meta(self, logical_key, meta):
         pkg = self._clone()
         pkg._data[logical_key].meta = meta
+        pkg._unset_tophash()
         return pkg
 
     def delete(self, logical_key):
@@ -457,6 +462,7 @@ class Package(object):
         """
         pkg = self._clone()
         pkg._data.pop(logical_key)
+        pkg._unset_tophash()
         return pkg
 
     def _top_hash(self):
@@ -482,6 +488,9 @@ class Package(object):
             'alg': 'v0',
             'value': top_hash.hexdigest()
         }
+
+    def _unset_tophash(self):
+        self._meta.pop('top_hash', None)
 
     def top_hash(self):
         """

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -263,6 +263,7 @@ class Package(object):
             # TODO: Warn if overwritting a logical key?
             pkg = pkg.set(logical_key, entry)
 
+        # modified package should have new top hash
         pkg._unset_tophash()
         return pkg
 
@@ -404,6 +405,7 @@ class Package(object):
         pkg = self._clone()
         for logical_key, entry in new_keys_dict.items():
             pkg = pkg.set(logical_key, entry, meta)
+        # modified package should have new top hash
         pkg._unset_tophash()
         return pkg
 
@@ -441,12 +443,15 @@ class Package(object):
                 raise PackageException("Must specify metadata in the entry")
         else:
             raise NotImplementedError
+        
+        # modified package should have new top hash
         pkg._unset_tophash()
         return pkg
 
     def _update_meta(self, logical_key, meta):
         pkg = self._clone()
         pkg._data[logical_key].meta = meta
+        # modified package should have new top hash
         pkg._unset_tophash()
         return pkg
 
@@ -462,6 +467,7 @@ class Package(object):
         """
         pkg = self._clone()
         pkg._data.pop(logical_key)
+        # modified package should have new top hash
         pkg._unset_tophash()
         return pkg
 

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -490,6 +490,12 @@ class Package(object):
         }
 
     def _unset_tophash(self):
+        """ 
+        Unsets the top hash
+        When a package is created from an existing package, the top hash
+            must be deleted so a correct new one can be calculated
+            when necessary
+        """
         self._meta.pop('top_hash', None)
 
     def top_hash(self):

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -405,8 +405,6 @@ class Package(object):
         pkg = self._clone()
         for logical_key, entry in new_keys_dict.items():
             pkg = pkg.set(logical_key, entry, meta)
-        # modified package should have new top hash
-        pkg._unset_tophash()
         return pkg
 
     def set(self, logical_key, entry=None, meta=None):


### PR DESCRIPTION
If we don't do this, then the new top hash will never be calculated (since it's cached in _meta) and packages will be hanging around with incorrect top hashes.