### PR TITLE
Don't use a `py.path.local` for appdirs return value

### DIFF
--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -39,7 +39,7 @@ def pytest_sessionstart(session):
     Vars.tmpdir_home = pytest.ensuretemp('fake_home')
     Vars.tmpdir_data = Vars.tmpdir_home.mkdir('appdirs_datadir')
 
-    user_data_dir = lambda *x: Vars.tmpdir_data / x[0] if x else Vars.tmpdir_data
+    user_data_dir = lambda *x: str(Vars.tmpdir_data / x[0] if x else Vars.tmpdir_data)
 
     # Mockers that need to be loaded before any of our code
     Vars.extrasession_mockers.extend([


### PR DESCRIPTION
### Problem:
`urllib.parse.urlparse` borks during testing, with `AttributeError: 'LocalPath' object has no attribute 'decode'`.

### Why:
* During testing, tempdirs generated by `pytest` are a string subclass -- `py.path.local`
* We use a tempdir when mocking `appdirs.user_data_dir()`
* `user_data_dir()` is used to make `BASE_DIR`, which makes its way into `urllib.parse.urlparse`
* apparently they also use a (different) string subclass, but `py.path.local` wins and becomes the object type instead of whatever they want
* they try to call 'decode' on an object that doesn't have that method

### Fix:
Changed return type of mocked `user_data_dir()` to `str`.

The issue has already been worked around in the test which brought it up, but this should prevent recurrence of similar problems.
