### PR TITLE
Suppress exception

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -347,7 +347,12 @@ def delete_object(path):
         s3_client.head_object(Bucket=bucket, Key=key)  # Make sure it exists
         s3_client.delete_object(Bucket=bucket, Key=key)  # Actually delete it
 
-NO_OP_COPY_ERROR_MESSAGE = "An error occurred (InvalidRequest) when calling the CopyObject operation: This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes."
+NO_OP_COPY_ERROR_MESSAGE = ("An error occurred (InvalidRequest) when calling "
+                            "the CopyObject operation: This copy request is illegal "
+                            "because it is trying to copy an object to itself "
+                            "without changing the object's metadata, storage "
+                            "class, website redirect location or encryption "
+                            "attributes.")
 
 def copy_object(src, dest, meta, version=None):
     src_bucket, src_key = split_path(src, require_subpath=True)


### PR DESCRIPTION
boto3 throws when we try to copy an object in s3 to itself without changing the metadata, storage class, etc. Suppress this exception because `copy_object` should work even when its source and destination are the same.

We can't tell whether a copy will be a no-op since we don't know if the provided `meta` argument matches the metadata on the source object.