### PR TITLE
Use URLs in get, put, ls, delete

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -13,7 +13,7 @@ from .data_transfer import (TargetType, copy_file, deserialize_obj, download_byt
                             upload_bytes, delete_object, list_objects,
                             list_object_versions, serialize_obj)
 from .packages import get_local_package_registry, get_package_registry
-from .util import (HeliumConfig, QuiltException, AWS_SEPARATOR, CONFIG_PATH,
+from .util import (HeliumConfig, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, fix_url, parse_file_url, parse_s3_url, read_yaml, validate_url,
                    write_yaml, yaml_has_comments)
 
@@ -62,9 +62,8 @@ def put(obj, dest, meta=None):
     if version:
         raise ValueError("Cannot push to a version")
 
-    if path.endswith(AWS_SEPARATOR):
-        raise ValueError("Invalid path: %r; ends with a %r"
-                         % (path, AWS_SEPARATOR))
+    if path.endswith('/'):
+        raise ValueError("Invalid path: %r; ends with a '/'" % path)
 
     data, target = serialize_obj(obj)
     all_meta = dict(

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -15,7 +15,7 @@ from s3transfer.subscribers import BaseSubscriber
 from six import BytesIO, binary_type, text_type
 from tqdm.autonotebook import tqdm
 
-from .util import QuiltException, split_path, parse_file_url, parse_s3_url
+from .util import QuiltException, parse_file_url, parse_s3_url
 from . import xattr
 
 
@@ -131,6 +131,21 @@ def serialize_obj(obj):
         raise QuiltException("Don't know how to serialize object")
 
     return data, target
+
+
+def split_path(path, require_subpath=False):
+    """
+    Split bucket name and intra-bucket path. Returns: (bucket, path)
+    """
+
+    result = path.split('/', 1)
+    if len(result) != 2:
+        raise ValueError("Invalid path: %r; expected BUCKET/PATH..." % path)
+    if require_subpath and not all(result):
+        raise ValueError("Invalid path: %r; expected BUCKET/PATH... (BUCKET and PATH both required)"
+                         % path)
+
+    return result
 
 
 class SizeCallback(BaseSubscriber):

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -23,8 +23,6 @@ BASE_DIR = user_data_dir(APP_NAME, APP_AUTHOR)
 BASE_PATH = pathlib.Path(BASE_DIR)
 CONFIG_PATH = BASE_PATH / 'config.yml'
 
-AWS_SEPARATOR = '/'
-
 PACKAGE_NAME_FORMAT = r"[\w-]+/[\w-]+$"
 
 ## CONFIG_TEMPLATE
@@ -57,21 +55,6 @@ class QuiltException(Exception):
         self.message = message
         for k, v in kwargs.items():
             setattr(self, k, v)
-
-
-def split_path(path, require_subpath=False):
-    """
-    Split bucket name and intra-bucket path. Returns: (bucket, path)
-    """
-
-    result = path.split(AWS_SEPARATOR, 1)
-    if len(result) != 2:
-        raise ValueError("Invalid path: %r; expected BUCKET/PATH..." % path)
-    if require_subpath and not all(result):
-        raise ValueError("Invalid path: %r; expected BUCKET/PATH... (BUCKET and PATH both required)"
-                         % path)
-
-    return result
 
 
 def fix_url(url):

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -41,7 +41,7 @@ class TestAPI():
         # and can cause issues when downloading to host machine.
         test_object = "foo"
         with pytest.raises(ValueError):
-            he.put(test_object, "test/")
+            he.put(test_object, "s3://test/")
 
     def test_search_no_config(self):
         with pytest.raises(util.QuiltException, match="No configured region."):


### PR DESCRIPTION
Note: this breaks the existing syntax! Try it and check if it's still ok.
In particular, I'm removing the `version` key from `get` cause it can now be part of the URL... but it's not very discoverable.