### PR TITLE
Remove an unnecessary write to the config backup file

### DIFF
--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -135,9 +135,6 @@ def write_yaml(data, yaml_path, keep_backup=False):
 
     backup_path = path.with_name(path.name + '.backup.' + now)
 
-    if path.exists():
-        backup_path.write_bytes(path.read_bytes())
-
     try:
         if path.exists():
             path.rename(backup_path)


### PR DESCRIPTION
We overwrite it immediately after that, by renaming the existing config file.
Also, that fails on Windows.