### PR TITLE
Disallow empty URLs

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -141,7 +141,7 @@ def list_packages(registry=None):
         A list of strings containing the names of the packages        
     """
     if not registry:
-        registry = ''
+        registry = 'whatever'
     registry = get_package_registry(fix_url(registry)).strip("/") + '/named_packages'
 
     registry_url = urlparse(registry)

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -196,7 +196,7 @@ class Package(object):
             raise QuiltException("Invalid package name, must contain exactly one /.")
 
 
-    def __init__(self, name=None, pkg_hash=None, registry=''):
+    def __init__(self, name=None, pkg_hash=None, registry='whatever'):
         """
         Create a Package from scratch, or load one from a registry.
 

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -76,6 +76,9 @@ def split_path(path, require_subpath=False):
 
 def fix_url(url):
     """Convert non-URL paths to file:// URLs"""
+    if not url:
+        raise ValueError("Empty URL")
+
     # If it has a scheme, we assume it's a URL.
     # On Windows, we ignore schemes that look like drive letters, e.g. C:/users/foo
     parsed = urlparse(url)


### PR DESCRIPTION
Defaulting to "." is counter-intuitive. If you really want ".", then use ".".