### PR TITLE
Implement Package.browse

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -189,30 +189,29 @@ class PackageEntry(object):
 class Package(object):
     """ In-memory representation of a package """
 
+    def __init__(self):
+        self._data = {}
+        self._meta = {'version': 'v0'}
+
+
     @staticmethod
     def validate_package_name(name):
         """ Verify that a package name is two alphanumerics strings separated by a slash."""
         if not re.match(PACKAGE_NAME_FORMAT, name):
             raise QuiltException("Invalid package name, must contain exactly one /.")
 
-        
+
     @staticmethod
-    def browse(name, pkg_hash=None, registry=''):
+    def browse(name=None, pkg_hash=None, registry=''):
         """
-        Create a Package from scratch, or load one from a registry.
+        Load a package into memory from a registry without making a local copy of
+        the manifest.
 
         Args:
             name(string): name of package to load
             pkg_hash(string): top hash of package version to load
             registry(string): location of registry to load package from
         """
-        if name is None and pkg_hash is None:
-            self._data = {}
-            self._meta = {'version': 'v0'}
-            return
-        elif name:
-            self.validate_package_name(name)
-
         registry = get_package_registry(fix_url(registry))
 
         if pkg_hash is not None:
@@ -221,6 +220,8 @@ class Package(object):
             pkg = Package._from_path(pkg_path)
             # Can't assign to self, so must mutate.
             return pkg
+        else:
+            Package.validate_package_name(name)
 
         pkg_path = '{}/named_packages/{}/'.format(registry, quote(name))
         latest = urlparse(pkg_path + 'latest')

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -195,8 +195,9 @@ class Package(object):
         if not re.match(PACKAGE_NAME_FORMAT, name):
             raise QuiltException("Invalid package name, must contain exactly one /.")
 
-
-    def __init__(self, name=None, pkg_hash=None, registry=''):
+        
+    @staticmethod
+    def browse(name, pkg_hash=None, registry=''):
         """
         Create a Package from scratch, or load one from a registry.
 
@@ -217,10 +218,9 @@ class Package(object):
         if pkg_hash is not None:
             # If hash is specified, name doesn't matter.
             pkg_path = '{}/packages/{}'.format(registry, pkg_hash)
-            pkg = self._from_path(pkg_path)
+            pkg = Package._from_path(pkg_path)
             # Can't assign to self, so must mutate.
-            self._set_state(pkg._data, pkg._meta)
-            return
+            return pkg
 
         pkg_path = '{}/named_packages/{}/'.format(registry, quote(name))
         latest = urlparse(pkg_path + 'latest')
@@ -237,9 +237,9 @@ class Package(object):
 
         latest_hash = latest_hash.strip()
         latest_path = '{}/packages/{}'.format(registry, quote(latest_hash))
-        pkg = self._from_path(latest_path)
+        pkg = Package._from_path(latest_path)
         # Can't assign to self, so must mutate.
-        self._set_state(pkg._data, pkg._meta)
+        return pkg
 
 
     @staticmethod

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -116,13 +116,13 @@ def test_browse_package_from_registry():
         pkghash = pkg.top_hash()
 
         # local load
-        pkg = Package(pkg_hash=pkghash)
+        pkg = Package.browse(pkg_hash=pkghash)
         assert registry + '/packages/{}'.format(pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
 
-        pkg = Package('Quilt/nice-name', pkg_hash=pkghash)
+        pkg = Package.browse('Quilt/nice-name', pkg_hash=pkghash)
         assert registry + '/packages/{}'.format(pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
@@ -130,7 +130,7 @@ def test_browse_package_from_registry():
 
         with patch('t4.packages.open') as open_mock:
             open_mock.return_value = io.BytesIO(pkghash.encode('utf-8'))
-            pkg = Package('Quilt/nice-name')
+            pkg = Package.browse('Quilt/nice-name')
             assert parse_file_url(urlparse(registry + '/named_packages/Quilt/nice-name/latest')) \
                     == open_mock.call_args_list[0][0][0]
 
@@ -140,18 +140,18 @@ def test_browse_package_from_registry():
 
         remote_registry = t4.packages.get_package_registry('s3://asdf/')
         # remote load
-        pkg = Package('Quilt/nice-name', registry=remote_registry, pkg_hash=pkghash)
+        pkg = Package.browse('Quilt/nice-name', registry=remote_registry, pkg_hash=pkghash)
         assert remote_registry + '/packages/{}'.format(pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
         pkgmock.reset_mock()
-        pkg = Package(pkg_hash=pkghash, registry=remote_registry)
+        pkg = Package.browse(pkg_hash=pkghash, registry=remote_registry)
         assert remote_registry + '/packages/{}'.format(pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
         with patch('t4.packages.download_bytes') as dl_mock:
             dl_mock.return_value = (pkghash.encode('utf-8'), None)
-            pkg = Package('Quilt/nice-name', registry=remote_registry)
+            pkg = Package.browse('Quilt/nice-name', registry=remote_registry)
         assert remote_registry + '/packages/{}'.format(pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -107,7 +107,7 @@ def test_materialize_from_remote(tmpdir):
                  patch('t4.Package.build', new=no_op_mock):
                 mat_pkg = pkg.push(os.path.join(tmpdir, 'pkg'), name='Quilt/test_pkg_name')
 
-def test_package_constructor_from_registry():
+def test_browse_package_from_registry():
     """ Verify loading manifest locally and from s3 """
     with patch('t4.Package._from_path') as pkgmock:
         registry = BASE_PATH.as_uri()


### PR DESCRIPTION
Removing the parameterized constructor and replacing it with a static method `browse` that reads a manifest from a remote or local registry into memory without copying the manifest file.