### PR TITLE
Implement registries at arbitrary locations

### DIFF
--- a/api/python/t4/__init__.py
+++ b/api/python/t4/__init__.py
@@ -14,4 +14,4 @@ from .api import (
     config,
 )
 
-from .packages import Package, get_local_package_registry, get_package_registry
+from .packages import Package

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse, urlunparse
 from .data_transfer import (TargetType, copy_file, deserialize_obj, download_bytes,
                             upload_bytes, delete_object, list_objects,
                             list_object_versions, serialize_obj)
-from .packages import get_local_package_registry, get_package_registry
+from .packages import get_package_registry
 from .util import (HeliumConfig, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, fix_url, parse_file_url, parse_s3_url, read_yaml, validate_url,
                    write_yaml, yaml_has_comments)
@@ -163,9 +163,7 @@ def list_packages(registry=None):
     Returns:
         A list of strings containing the names of the packages        
     """
-    if not registry:
-        registry = ''
-    registry = get_package_registry(fix_url(registry)).strip("/") + '/named_packages'
+    registry = get_package_registry(fix_url(registry) if registry else None) + '/named_packages'
 
     registry_url = urlparse(registry)
     if registry_url.scheme == 'file':

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -61,6 +61,11 @@ def fix_url(url):
     """Convert non-URL paths to file:// URLs"""
     # If it has a scheme, we assume it's a URL.
     # On Windows, we ignore schemes that look like drive letters, e.g. C:/users/foo
+    if not url:
+        raise ValueError("Empty URL")
+
+    url = str(url)
+
     parsed = urlparse(url)
     if parsed.scheme and not os.path.splitdrive(url)[0]:
         return url


### PR DESCRIPTION
Also hide `get_package_registry` from the user: the user should pass in normal URLs or None, and we'll append '.quilt' or get the default registry as needed.

One weirdness that came up: the `registry` arg in `build` is just a normal path. So we two methods like this:
- `build(name, path)`
- `push(path, name)`
Should probably pick one convention.