### PR TITLE
Make everything work on Windows

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -168,7 +168,7 @@ def list_packages(registry=None):
     registry_url = urlparse(registry)
     if registry_url.scheme == 'file':
         registry_dir = pathlib.Path(parse_file_url(registry_url))
-        return [str(x.relative_to(registry_dir)) for x in registry_dir.glob('*/*')]
+        return [x.relative_to(registry_dir).as_posix() for x in registry_dir.glob('*/*')]
 
     elif registry_url.scheme == 's3':
         src_bucket, src_path, _ = parse_s3_url(registry_url)


### PR DESCRIPTION
Windows does not allow opening the same file twice, so `NamedTemporaryFile` pretty much can't work... But, there's actually no reason to create temporary file just to copy it somewhere else. So add a `copy_bytes` helper.