### PR TITLE
Make Package.set accept anything that can be used as a path

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -12,7 +12,7 @@ import time
 from urllib.parse import quote, urlparse
 
 import jsonlines
-from six import string_types
+from six import string_types, binary_type
 
 from .data_transfer import copy_bytes, copy_file, deserialize_obj, download_bytes, TargetType
 
@@ -580,7 +580,7 @@ class Package(object):
         if entry is None:
             return self._update_meta(logical_key, meta)
 
-        if isinstance(entry, str):
+        if isinstance(entry, (string_types, binary_type, getattr(os, 'PathLike'))):
             entry = PackageEntry.from_local_path(entry)
             if meta is not None:
                 entry.meta = meta

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -360,12 +360,12 @@ def test_tophash_changes(tmpdir):
 
     pkg = Package()
     th1 = pkg.top_hash()
-    pkg.set('asdf', str(test_file))
+    pkg.set('asdf', test_file)
     th2 = pkg.top_hash()
     assert th1 != th2
 
     test_file.write_text('jkl', 'utf-8')
-    pkg.set('jkl', str(test_file))
+    pkg.set('jkl', test_file)
     th3 = pkg.top_hash()
     assert th1 != th3
     assert th2 != th3
@@ -404,7 +404,7 @@ def test_invalid_set_key(tmpdir):
     """Verify an exception when setting a key with a path object."""
     pkg = Package()
     with pytest.raises(NotImplementedError):
-        pkg.set('asdf/jkl', tmpdir)
+        pkg.set('asdf/jkl', 123)
 
 def test_brackets():
     pkg = Package()


### PR DESCRIPTION
Accept strings, bytes, and os.PathLike (if it exists - Python 3.6 and above)