### PR TITLE
Get rid of split_path and the "legacy" bucket/path syntax

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -98,7 +98,7 @@ def delete(target):
     if version:
         raise ValueError("Cannot delete a version")
 
-    delete_object(bucket + '/' + path)
+    delete_object(bucket, path)
 
 
 def ls(target, recursive=False):
@@ -130,7 +130,7 @@ def ls(target, recursive=False):
     if path and not path.endswith('/'):
         path += '/'
 
-    results = list_object_versions(bucket + '/' + path, recursive=recursive)
+    results = list_object_versions(bucket, path, recursive=recursive)
 
     return results
 
@@ -156,12 +156,12 @@ def list_packages(registry=None):
 
     elif registry_url.scheme == 's3':
         src_bucket, src_path, _ = parse_s3_url(registry_url)
-        prefixes, _ = list_objects(src_bucket + '/' + src_path + '/', recursive=False)
+        prefixes, _ = list_objects(src_bucket, src_path + '/', recursive=False)
         # Pull out the directory fields and remove the src_path prefix.
         names = []
         # Search each org directory for named packages.
         for org in [x['Prefix'][len(src_path):].strip('/') for x in prefixes]:
-            packages, _ = list_objects(src_bucket + '/' + src_path + '/' + org + '/', recursive=False)
+            packages, _ = list_objects(src_bucket, src_path + '/' + org + '/', recursive=False)
             names.extend(y['Prefix'][len(src_path):].strip('/') for y in packages)
         return names
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -133,21 +133,6 @@ def serialize_obj(obj):
     return data, target
 
 
-def split_path(path, require_subpath=False):
-    """
-    Split bucket name and intra-bucket path. Returns: (bucket, path)
-    """
-
-    result = path.split('/', 1)
-    if len(result) != 2:
-        raise ValueError("Invalid path: %r; expected BUCKET/PATH..." % path)
-    if require_subpath and not all(result):
-        raise ValueError("Invalid path: %r; expected BUCKET/PATH... (BUCKET and PATH both required)"
-                         % path)
-
-    return result
-
-
 class SizeCallback(BaseSubscriber):
     def __init__(self, size):
         self.size = size
@@ -276,10 +261,8 @@ def _download_dir(bucket, prefix, dest_path):
             xattr.setxattr(dest_file, HELIUM_XATTR, json.dumps(meta).encode('utf-8'))
 
 
-def download_file(src_path, dest_path, version=None):
-    bucket, key = split_path(src_path)
-
-    if src_path.endswith('/'):
+def download_file(bucket, key, dest_path, version=None):
+    if key.endswith('/'):
         if version is not None:
             raise QuiltException("Cannot specify a Version ID for a directory.")
         _download_dir(bucket, key, dest_path)
@@ -311,7 +294,7 @@ def _calculate_etag(file_obj):
     return '"%s"' % etag
 
 
-def upload_file(src_path, dest_path, override_meta=None):
+def upload_file(src_path, bucket, key, override_meta=None):
     src_file = pathlib.Path(src_path)
     is_dir = src_file.is_dir()
     if src_path.endswith('/'):
@@ -329,8 +312,6 @@ def upload_file(src_path, dest_path, override_meta=None):
     else:
         src_root = src_file.parent
         src_file_list = [src_file]
-
-    bucket, key = split_path(dest_path)
 
     total_size = sum(f.stat().st_size for f in src_file_list)
 
@@ -378,10 +359,8 @@ def upload_file(src_path, dest_path, override_meta=None):
             future.result()
 
 
-def delete_object(path):
-    bucket, key = split_path(path, require_subpath=True)
-
-    if path.endswith('/'):
+def delete_object(bucket, key):
+    if key.endswith('/'):
         for response in _list_objects(Bucket=bucket, Prefix=key):
             for obj in response.get('Contents', []):
                 s3_client.delete_object(Bucket=bucket, Key=obj['Key'])
@@ -396,9 +375,7 @@ NO_OP_COPY_ERROR_MESSAGE = ("An error occurred (InvalidRequest) when calling "
                             "class, website redirect location or encryption "
                             "attributes.")
 
-def copy_object(src, dest, override_meta=None, version=None):
-    src_bucket, src_key = split_path(src, require_subpath=True)
-    dest_bucket, dest_key = split_path(dest, require_subpath=True)
+def copy_object(src_bucket, src_key, dest_bucket, dest_key, override_meta=None, version=None):
     src_params = dict(
         Bucket=src_bucket,
         Key=src_key
@@ -432,10 +409,9 @@ def copy_object(src, dest, override_meta=None, version=None):
         raise
 
 
-def list_object_versions(path, recursive=True):
-    bucket, key = split_path(path)
+def list_object_versions(bucket, prefix, recursive=True):
     list_obj_params = dict(Bucket=bucket,
-                           Prefix=key
+                           Prefix=prefix
                           )
     if not recursive:
         # Treat '/' as a directory separator and only return one level of files instead of everything.
@@ -457,8 +433,7 @@ def list_object_versions(path, recursive=True):
         return prefixes, versions, delete_markers
 
 
-def list_objects(path, recursive=True):
-    bucket, prefix = split_path(path)
+def list_objects(bucket, prefix, recursive=True):
     objects = []
     prefixes = []
     list_obj_params = dict(Bucket=bucket,
@@ -498,19 +473,19 @@ def copy_file(src, dest, override_meta=None):
             dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
             if dest_version_id:
                 raise ValueError("Cannot set VersionId on destination")
-            upload_file(parse_file_url(src_url), dest_bucket + '/' + dest_path, override_meta)
+            upload_file(parse_file_url(src_url), dest_bucket, dest_path, override_meta)
         else:
             raise NotImplementedError
     elif src_url.scheme == 's3':
         src_bucket, src_path, src_version_id = parse_s3_url(src_url)
         if dest_url.scheme == 'file':
             pathlib.Path(parse_file_url(dest_url)).parent.mkdir(parents=True, exist_ok=True)
-            download_file(src_bucket + '/' + src_path, parse_file_url(dest_url), src_version_id)
+            download_file(src_bucket, src_path, parse_file_url(dest_url), src_version_id)
         elif dest_url.scheme == 's3':
             dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
             if dest_version_id:
                 raise ValueError("Cannot set VersionId on destination")
-            copy_object(src_bucket + '/' + src_path, dest_bucket + '/' + dest_path, override_meta, src_version_id)
+            copy_object(src_bucket, src_path, dest_bucket, dest_path, override_meta, src_version_id)
         else:
             raise NotImplementedError
     else:

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -475,8 +475,7 @@ def test_list_remote_packages():
     with patch('t4.api.list_objects',
                return_value=([{'Prefix': 'foo'},{'Prefix': 'bar'}],[])) as mock:
         pkgs = t4.list_packages('s3://my_test_bucket/')
-        assert mock.call_args_list[0][0][0] == \
-            'my_test_bucket/.quilt/named_packages/'
+        assert mock.call_args_list[0][0] == ('my_test_bucket', '.quilt/named_packages/')
 
     assert True
 


### PR DESCRIPTION
We're using URLs in the public API - while in the private helper functions, might as well use bucket and keys instead of parsing things.