### PR TITLE
Simple PackageEntry repr

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -92,7 +92,7 @@ class PackageEntry(object):
         )
 
     def __repr__(self):
-        return f"PackageNode('{self.physical_keys[0]}')"
+        return f"PackageEntry('{self.physical_keys[0]}')"
 
     def as_dict(self):
         """

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -91,6 +91,9 @@ class PackageEntry(object):
             and self.meta == other.meta
         )
 
+    def __repr__(self):
+        return f"PackageNode('{self.physical_keys[0]}')"
+
     def as_dict(self):
         """
         Returns dict representation of entry.


### PR DESCRIPTION
The `PackageEntry` `__repr__` will now look something like this:

```python
PackageEntry('s3://alpha-quilt-storage/foo/bar.csv')
```

This has just the package physical key in the string representation, which is unambiguous because (AFAIK) the string is name-spaced before it's attached to, so it'll always be `file:///something` or `s3://something`.

It is not possible to include the logical key in the `PackageEntry` representation because `PackageEntry` objects are not aware of their own parent name. But if in the future we make them aware of their path to the package root, another possibility might be:

```python
PackageEntry('bar.csv', 's3://alpha-quilt-storage/foo/bar.csv')
```

**Edit**: replaced errant `PackageNode` references with correct `PackageEntry` references.