### PR TITLE
fix missing rename of `dest_path` to `key` for dir check in `upload_file()`

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -300,7 +300,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
     if src_path.endswith('/'):
         if not is_dir:
             raise ValueError("Source path not a directory")
-        if not dest_path.endswith('/'):
+        if not key.endswith('/'):
             raise ValueError("Destination path must end in /")
     else:
         if is_dir:


### PR DESCRIPTION
Looks like someone missed a var when changing `dest_path` to `bucket` and `key`.  Easily remedied..