### PR TITLE
Make `PackageEntry.deserialize()` take deserializer override

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -196,8 +196,12 @@ class PackageEntry(object):
             of the data that would have been deserialized, then its
             return value is returned.
 
-            Example:
-                p[k](lambda k: json.loads(Path(urlparse(k).path).read_text()))
+            Example for decoding a json blob:
+                >>> des = lambda k: json.loads(Path(urlparse(k).path).read_text())
+                >>> obj = p[k](des)  # obj is the deserialized JSON blob
+
+            This is particularly useful when a key has no metadata associated
+            with it, or when the serialization metadata needs to be overridden.
 
         Args:
             deserializer: use the given function for deserialization.

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1,6 +1,7 @@
 """ Integration tests for T4 Packages. """
 import appdirs
 import io
+import json
 import jsonlines
 import os
 import pathlib
@@ -514,3 +515,18 @@ def test_diff():
     p1 = Package.browse('Quilt/Test')
     p2 = Package.browse('Quilt/Test')
     assert p1.diff(p2) == ([], [], [])
+
+
+def test_lambda_deserializers():
+    test_data = {'foo': 'bar'}
+    f = Path('test_lambda_deserializers')
+    f.write_text(json.dumps(test_data))
+
+    p = t4.Package()
+    p.set('test', 'test_lambda_deserializers')
+
+    with pytest.raises(QuiltException):
+        p['test']()
+
+    deserializer = lambda pk: json.loads(Path(urlparse(pk).path).read_text())
+    assert p['test'](deserializer) == test_data


### PR DESCRIPTION
Allow an argument for deserialize, so that:
`des(p.get(k))`
can be written as:
`p[k].deserialize(des)`
..and therefore, the nice, natural, and succinct:
`p[k](des)`

* The provide deserializer overrides any deserializer specified in the metadata.
* PackageEntry deserialization failures now reference `PackageEntry.deserialize` docs.