### PR TITLE
Add commit on push and build

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -519,6 +519,24 @@ class Package(object):
         entry = self._data[logical_key]
         return entry.meta
 
+    def _set_commit_message(self, msg):
+        """
+        Sets a commit message.
+
+        Args:
+            msg: a message string
+
+        Returns:
+            None
+
+        Raises:
+            msg is not a string
+        """
+        if not isinstance(msg, str):
+            raise ValueError("The commit message must be a string.")
+
+        self._meta.update({'commit_message': msg})
+
     def build(self, name=None, registry=None, message=None):
         """
         Serializes this package to a registry.
@@ -532,7 +550,7 @@ class Package(object):
         Returns:
             the top hash as a string
         """
-        self._meta.update({'commit_message': message})
+        self._set_commit_message(message)
 
         registry_prefix = get_package_registry(fix_url(registry) if registry else None)
 
@@ -697,8 +715,7 @@ class Package(object):
             A new package that points to the copied objects
         """
         self.validate_package_name(name)
-
-        self._meta.update({'commit_message': message})
+        self._set_commit_message(message)
 
         if registry is None:
             registry = dest

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -539,10 +539,10 @@ class Package(object):
             None
 
         Raises:
-            msg is not a string
+            a ValueError if msg is not a string
         """
         if msg is not None and not isinstance(msg, str):
-            raise ValueError("The commit message must be a string.")
+            raise ValueError("The package message must be a string.")
 
         self._meta.update({'message': msg})
 

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -532,7 +532,7 @@ class Package(object):
         Raises:
             msg is not a string
         """
-        if not isinstance(msg, str):
+        if msg is not None and not isinstance(msg, str):
             raise ValueError("The commit message must be a string.")
 
         self._meta.update({'commit_message': msg})

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -519,7 +519,7 @@ class Package(object):
         entry = self._data[logical_key]
         return entry.meta
 
-    def build(self, name=None, registry=None):
+    def build(self, name=None, registry=None, message=None):
         """
         Serializes this package to a registry.
 
@@ -527,10 +527,13 @@ class Package(object):
             name: optional name for package
             registry: registry to build to
                     defaults to local registry
+            message: the commit message of the package
 
         Returns:
             the top hash as a string
         """
+        self._meta.update({'commit_message': message})
+
         registry_prefix = get_package_registry(fix_url(registry) if registry else None)
 
         hash_string = self.top_hash()
@@ -679,7 +682,7 @@ class Package(object):
 
         return top_hash.hexdigest()
 
-    def push(self, name, dest, registry=None):
+    def push(self, name, dest, registry=None, message=None):
         """
         Copies objects to path, then creates a new package that points to those objects.
         Copies each object in this package to path according to logical key structure,
@@ -689,10 +692,13 @@ class Package(object):
             name: name for package in registry
             dest: where to copy the objects in the package
             registry: registry where to create the new package
+            message: the commit message for the new package
         Returns:
             A new package that points to the copied objects
         """
         self.validate_package_name(name)
+
+        self._meta.update({'commit_message': message})
 
         if registry is None:
             registry = dest

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -535,7 +535,7 @@ class Package(object):
         if msg is not None and not isinstance(msg, str):
             raise ValueError("The commit message must be a string.")
 
-        self._meta.update({'commit_message': msg})
+        self._meta.update({'message': msg})
 
     def build(self, name=None, registry=None, message=None):
         """

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -408,9 +408,6 @@ def test_tophash_changes(tmpdir):
     th4 = pkg.top_hash()
     assert th2 == th4
 
-    pkg.delete('asdf')
-    assert th1 == pkg.top_hash()
-
 def test_keys():
     pkg = Package()
     assert not pkg.keys()

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -521,7 +521,7 @@ def test_diff():
     assert p1.diff(p2) == ([], [], [])
 
 
-    def test_dir_meta(tmpdir):
+def test_dir_meta(tmpdir):
     test_meta = {'test': 'meta'}
     pkg = Package()
     pkg.set('asdf/jkl', LOCAL_MANIFEST)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -514,3 +514,19 @@ def test_diff():
     p1 = Package.browse('Quilt/Test')
     p2 = Package.browse('Quilt/Test')
     assert p1.diff(p2) == ([], [], [])
+
+
+def test_commit_message_on_push(tmpdir):
+    """ Verify commit messages populate correctly on push."""
+    with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+        with open(REMOTE_MANIFEST) as fd:
+            pkg = Package.load(fd)
+        with patch('t4.data_transfer._download_single_file', new=no_op_mock), \
+                patch('t4.data_transfer._download_dir', new=no_op_mock), \
+                patch('t4.Package.build', new=no_op_mock):
+            pkg.push('Quilt/test_pkg_name', tmpdir / 'pkg', message='test_message')
+            assert pkg._meta['commit_message'] == 'test_message'
+
+            # ensure messages are strings
+            with pytest.raises(ValueError):
+                pkg.push('Quilt/test_pkg_name', tmpdir / 'pkg', message={})

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -525,7 +525,7 @@ def test_commit_message_on_push(tmpdir):
                 patch('t4.data_transfer._download_dir', new=no_op_mock), \
                 patch('t4.Package.build', new=no_op_mock):
             pkg.push('Quilt/test_pkg_name', tmpdir / 'pkg', message='test_message')
-            assert pkg._meta['commit_message'] == 'test_message'
+            assert pkg._meta['message'] == 'test_message'
 
             # ensure messages are strings
             with pytest.raises(ValueError):


### PR DESCRIPTION
`push` and `build` now accept an optional `message` `kwarg`.

On `push` and `build`, this `kwarg` will be inserted into the package metadata as a `commit_message: message` key-value pair. If no message is specified, `message` will be `None`.