### PR TITLE
Rename helium to t4 and pyarrow to parquet

### DIFF
--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -17,4 +17,4 @@ def test_buggy_parquet():
     path = pathlib.Path(__file__).parent
     with open(path / 'data' / 'buggy_parquet.parquet', 'rb') as bad_parq:
         # Make sure this doesn't crash.
-        deserialize_obj(bad_parq.read(), TargetType.PYARROW)
+        deserialize_obj(bad_parq.read(), TargetType.PARQUET)


### PR DESCRIPTION
- Rename the metadata header and xattr from "helium" to "t4"
- Rename "PYARROW" to "PARQUET", since Parquet is the name of the format

NOTE: This breaks metadata on all existing objects out there! I can support the old metadata if needed.