### PR TITLE
Stop storing top_hash in the manifest

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -424,8 +424,7 @@ class Package(object):
         """
         reader = jsonlines.Reader(readable_file)
         meta = reader.read()
-        # Pop the top hash -- it should only be calculated dynamically
-        meta.pop('top_hash', None)
+        meta.pop('top_hash', None)  # Obsolete
         pkg = cls()
         pkg._meta = meta
         for obj in reader:
@@ -543,7 +542,7 @@ class Package(object):
 
             named_path = registry_prefix + '/named_packages/' + quote(name) + '/'
             # todo: use a float to string formater instead of double casting
-            hash_bytes = self.top_hash().encode('utf-8')
+            hash_bytes = hash_string.encode('utf-8')
             timestamp_path = named_path + str(int(time.time()))
             latest_path = named_path + "latest"
             put_bytes(hash_bytes, timestamp_path)
@@ -565,14 +564,8 @@ class Package(object):
             fail to create file
             fail to finish write
         """
-        self.top_hash() # Assure top hash is calculated.
         writer = jsonlines.Writer(writable_file)
-        top_level_meta = self._meta
-        top_level_meta['top_hash'] = {
-            'alg': 'v0',
-            'value': self.top_hash()
-        }
-        writer.write(top_level_meta)
+        writer.write(self._meta)
         for logical_key, entry in self.walk():
             writer.write({'logical_key': logical_key, **entry.as_dict()})
 
@@ -671,9 +664,8 @@ class Package(object):
             A string that represents the top hash of the package
         """
         top_hash = hashlib.sha256()
-        hashable_meta = copy.deepcopy(self._meta)
-        hashable_meta.pop('top_hash', None)
-        top_meta = json.dumps(hashable_meta, sort_keys=True, separators=(',', ':'))
+        assert 'top_hash' not in self._meta
+        top_meta = json.dumps(self._meta, sort_keys=True, separators=(',', ':'))
         top_hash.update(top_meta.encode('utf-8'))
         for logical_key, entry in self.walk():
             entry_dict = entry.as_dict()

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -424,7 +424,7 @@ class Package(object):
         """
         reader = jsonlines.Reader(readable_file)
         meta = reader.read()
-        meta.pop('top_hash', None)  # Obsolete
+        meta.pop('top_hash', None)  # Obsolete as of PR #130
         pkg = cls()
         pkg._meta = meta
         for obj in reader:

--- a/api/python/tests/integration/data/local_manifest.jsonl
+++ b/api/python/tests/integration/data/local_manifest.jsonl
@@ -1,4 +1,4 @@
-{"semver": "1.1.1","comment": "example schema","top_hash": {"alg": "v0", "value": "c65a7b673b106c8051bd04db0976e84565dd1b5fc398f25b51eed79d2ff8bbfd"},"quilt_schema_version": "0.0.1"}
+{"semver": "1.1.1","comment": "example schema","quilt_schema_version": "0.0.1"}
 {"logical_key":"foo","physical_keys":["file:///foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"bar.csv","physical_keys":["file:///bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"baz/bat","physical_keys":["file:///User/home/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}

--- a/api/python/tests/integration/data/t4_manifest.jsonl
+++ b/api/python/tests/integration/data/t4_manifest.jsonl
@@ -1,4 +1,4 @@
-{"semver": "1.1.1","comment": "example schema","top_hash": {"type": "example", "value": "deadbeef"},"quilt_schema_version": "0.0.1"}
+{"semver": "1.1.1","comment": "example schema","quilt_schema_version": "0.0.1"}
 {"logical_key":"foo","physical_keys":["s3://my_bucket/my_data_pkg/foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"bar.csv","physical_keys":["s3://my_bucket/my_data_pkg/bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"baz/bat","physical_keys":["s3://my_bucket/my_data_pkg/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}


### PR DESCRIPTION
It's not actually used for anything... and it shouldn't be - we just calculate it as needed.