### PR TITLE
Fall back to unsigned boto client if user doesn't have valid AWS credentials

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -35,7 +35,7 @@ if platform.system() == 'Linux':
 s3_client = boto3.client('s3')
 try:
     s3_client.head_bucket(Bucket='alpha-quilt-storage')
-except ClientError, NoCredentialsError:
+except (ClientError, NoCredentialsError):
     # Use unsigned boto if credentials can't head the default bucket
     s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -8,6 +8,8 @@ import shutil
 from threading import Lock
 from urllib.parse import urlparse
 
+from botocore import UNSIGNED
+from botocore.client import Config
 from botocore.exceptions import ClientError
 import boto3
 from boto3.s3.transfer import TransferConfig, create_transfer_manager
@@ -31,6 +33,12 @@ if platform.system() == 'Linux':
     HELIUM_XATTR = 'user.%s' % HELIUM_XATTR
 
 s3_client = boto3.client('s3')
+try:
+    s3_client.head_object(Bucket='alpha-quilt-storage')
+except ClientError:
+    # Use unsigned boto if credentials can't head the default bucket
+    s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
 s3_transfer_config = TransferConfig()
 s3_manager = create_transfer_manager(s3_client, s3_transfer_config)
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -34,7 +34,7 @@ if platform.system() == 'Linux':
 
 s3_client = boto3.client('s3')
 try:
-    s3_client.head_object(Bucket='alpha-quilt-storage')
+    s3_client.head_bucket(Bucket='alpha-quilt-storage')
 except ClientError:
     # Use unsigned boto if credentials can't head the default bucket
     s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 from botocore import UNSIGNED
 from botocore.client import Config
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 import boto3
 from boto3.s3.transfer import TransferConfig, create_transfer_manager
 from s3transfer.subscribers import BaseSubscriber
@@ -35,7 +35,7 @@ if platform.system() == 'Linux':
 s3_client = boto3.client('s3')
 try:
     s3_client.head_bucket(Bucket='alpha-quilt-storage')
-except ClientError:
+except ClientError, NoCredentialsError:
     # Use unsigned boto if credentials can't head the default bucket
     s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -34,7 +34,11 @@ if platform.system() == 'Linux':
 
 s3_client = boto3.client('s3')
 try:
-    s3_client.head_bucket(Bucket='alpha-quilt-storage')
+    # Ensure that user has AWS credentials that function.
+    # quilt-example is readable by anonymous users, if the head fails
+    #   then the s3 client needs to be in UNSIGNED mode
+    #   because the user's credentials aren't working
+    s3_client.head_bucket(Bucket='quilt-example')
 except (ClientError, NoCredentialsError):
     # Use unsigned boto if credentials can't head the default bucket
     s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))


### PR DESCRIPTION
`alpha-quilt-storage` is a placeholder for some public bucket that you should be able to HEAD. We should replace this with something that makes sense, suggestions welcome