### PR TITLE
Implement a delete_dir top-level method

### DIFF
--- a/api/python/t4/__init__.py
+++ b/api/python/t4/__init__.py
@@ -8,6 +8,7 @@ from .api import (
     put,
     get,
     delete,
+    delete_dir,
     ls,
     list_packages,
     search,

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -101,6 +101,25 @@ def delete(target):
     delete_object(bucket, path)
 
 
+def delete_dir(target):
+    """Delete a remote directory.
+
+    Parameters:
+            target (str): URI of the directory to delete
+    """
+    url = urlparse(target)
+    if url.scheme != 's3':
+        raise NotImplementedError
+
+    bucket, path, version = parse_s3_url(url)
+    if version:
+        raise ValueError("Versions don't make sense for directories")
+
+    results = list_object_versions(bucket, path, recursive=True)
+    for result in results[0]:
+        delete('s3://' + bucket + '/' + result['Key'])
+
+
 def ls(target, recursive=False):
     """List data from the specified path.
 

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -115,8 +115,8 @@ def delete_dir(target):
     if version:
         raise ValueError("Versions don't make sense for directories")
 
-    results = list_object_versions(bucket, path, recursive=True)
-    for result in results[0]:
+    results = list_objects(bucket, path)
+    for result in results:
         delete('s3://' + bucket + '/' + result['Key'])
 
 

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -8,7 +8,6 @@ from ruamel.yaml import YAML
 import t4 as he
 from t4 import util
 
-
 class TestAPI():
     @responses.activate
     def test_config(self):


### PR DESCRIPTION
Note: per earlier discussion, the next step after landing this PR is to implement a user confirmation for all of `delete`, `delete_dir`, and `delete_package`.