### PR TITLE
Add version ids to physical keys when materializing

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -15,6 +15,7 @@ import boto3
 from boto3.s3.transfer import TransferConfig, create_transfer_manager
 from s3transfer.subscribers import BaseSubscriber
 from six import BytesIO, binary_type, text_type
+from urllib.parse import quote
 
 import warnings
 with warnings.catch_warnings():
@@ -342,7 +343,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
     else:
         src_root = src_file.parent
         src_file_list = [src_file]
-        versioned_key = []
+        versioned_key = [None]
 
     total_size = sum(f.stat().st_size for f in src_file_list)
 
@@ -374,7 +375,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
             def meta_callback(bucket, real_dest_path, versioned_key):
                 def cb(resp):
                     version_id = resp.get('VersionId', 'null')  # Absent in unversioned buckets.
-                    if versioned_key:
+                    if versioned_key is not None:
                         obj_url = 's3://%s/%s' % (bucket, real_dest_path)
                         if version_id != 'null':  # Yes, 'null'
                             obj_url += '?versionId=%s' % quote(version_id)

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -338,9 +338,11 @@ def upload_file(src_path, bucket, key, override_meta=None):
     if is_dir:
         src_root = src_file
         src_file_list = list(f for f in src_file.rglob('*') if f.is_file())
+        versioned_key = None
     else:
         src_root = src_file.parent
         src_file_list = [src_file]
+        versioned_key = []
 
     total_size = sum(f.stat().st_size for f in src_file_list)
 
@@ -369,13 +371,18 @@ def upload_file(src_path, bucket, key, override_meta=None):
             else:
                 meta = override_meta
 
-            def meta_callback(f):
+            def meta_callback(bucket, real_dest_path, versioned_key):
                 def cb(resp):
-                    version_id = resp.get('VersionId')  # Absent in unversioned buckets.
-                    # TODO: Use the version_id.
+                    version_id = resp.get('VersionId', 'null')  # Absent in unversioned buckets.
+                    if versioned_key:
+                        obj_url = 's3://%s/%s' % (bucket, real_dest_path)
+                        if version_id != 'null':  # Yes, 'null'
+                            obj_url += '?versionId=%s' % quote(version_id)
+                        versioned_key[0] = obj_url
                 return cb
 
-            extra_args = dict(Metadata={HELIUM_METADATA: json.dumps(meta)}, Callback=meta_callback(f))
+            extra_args = dict(Metadata={HELIUM_METADATA: json.dumps(meta)},
+                              Callback=meta_callback(bucket, real_dest_path, versioned_key))
             existing_src = existing_etags.get(etag)
             if existing_src is not None:
                 # We found an existing object with the same ETag, so copy it instead of uploading
@@ -392,7 +399,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
 
         for future in futures:
             future.result()
-
+    return versioned_key
 
 def delete_object(bucket, key):
     if key.endswith('/'):
@@ -436,7 +443,12 @@ def copy_object(src_bucket, src_key, dest_bucket, dest_key, override_meta=None, 
         ))
 
     try:
-        s3_client.copy_object(**params)
+        resp = s3_client.copy_object(**params)
+        version_id = resp.get('VersionId', 'null')  # Absent in unversioned buckets.
+        obj_url = 's3://%s/%s' % (dest_bucket, dest_key)
+        if version_id != 'null':  # Yes, 'null'
+            obj_url += '?versionId=%s' % quote(version_id)
+        return [obj_url]
     except ClientError as e:
         # suppress error from copying a file to itself
         if str(e) == NO_OP_COPY_ERROR_MESSAGE:
@@ -514,7 +526,7 @@ def copy_file(src, dest, override_meta=None):
             dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
             if dest_version_id:
                 raise ValueError("Cannot set VersionId on destination")
-            upload_file(parse_file_url(src_url), dest_bucket, dest_path, override_meta)
+            return upload_file(parse_file_url(src_url), dest_bucket, dest_path, override_meta)
         else:
             raise NotImplementedError
     elif src_url.scheme == 's3':
@@ -526,7 +538,8 @@ def copy_file(src, dest, override_meta=None):
             dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
             if dest_version_id:
                 raise ValueError("Cannot set VersionId on destination")
-            copy_object(src_bucket, src_path, dest_bucket, dest_path, override_meta, src_version_id)
+            return copy_object(src_bucket, src_path, dest_bucket, dest_path, override_meta,
+                               src_version_id)
         else:
             raise NotImplementedError
     else:

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -878,10 +878,11 @@ class Package(object):
             # Copy the datafiles in the package.
             physical_key = _to_singleton(entry.physical_keys)
             new_physical_key = dest_url + "/" + quote(logical_key)
-            copy_file(physical_key, new_physical_key, entry.meta)
+            versioned_key = copy_file(physical_key, new_physical_key, entry.meta)
 
             # Create a new package entry pointing to the new remote key.
             new_entry = entry._clone()
+            new_physical_key = versioned_key[0] if versioned_key else new_physical_key
             new_entry.physical_keys = [new_physical_key]
             pkg.set(logical_key, new_entry)
         return pkg


### PR DESCRIPTION
```
p = t4.Package()
p.set('sindelar-test/foo2.txt', 'foo.txt')
p.push('quilt/sindelar-test', f'{bucket_name}')
```

```
>>> p2 = t4.Package.browse("quilt/sindelar-test", registry="s3://alpha-quilt-storage")
>>> p2["sindelar-test"]["foo2.txt"]
PackageEntry('s3://alpha-quilt-storage/quilt/sindelar-test/sindelar-test/foo2.txt?versionId=Rh6SuoxNeij6ErHNVt2uDBThLD.CkIYs')
>>> p2["sindelar-test"]["foo2.txt"].get()
's3://alpha-quilt-storage/quilt/sindelar-test/sindelar-test/foo2.txt?versionId=Rh6SuoxNeij6ErHNVt2uDBThLD.CkIYs'
>>> p2["sindelar-test"]["foo2.txt"].fetch("./")
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.00/7.00 [00:00<00:00, 69.5B/s]
```

Example manifest with bundled version:

https://alpha.quiltdata.com/b/alpha-quilt-storage/tree/.quilt/packages/472effa9ba2ac9493dff13b9c4b267915fdb62796a6eff826fd50152487f9915