### PR TITLE
Pypi ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,4 +99,5 @@ jobs:
           name: upload to pypi
           command: |
             . venv/bin/activate
+            pip install twine
             twine upload dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)*(\-[a-ZA-Z])*/
             branches:
               ignore: /.*/
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,32 @@ jobs:
             . venv/bin/activate
             cd api/python && pytest --cov=./
             codecov
+  build:
+    docker:
+      - image: circleci/python:3.6-jessie
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -e api/python[tests]
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          paths:
+            - "venv"
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            cd api/python && pytest --cov=./
+            codecov
+      - store_artifacts:
+          path: htmlcov/
+
   deploy:
     docker:
       - image: circleci/python:3.6-jessie

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(\-[a-z])*/
+              only: /[0-9]+(\.[0-9]+)*[-a-z]+/
 jobs:
   test-3.6: &test-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ workflows:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*(\-[a-z])*/
-            branches:
-              ignore: /.*/
 jobs:
   test-3.6: &test-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,5 +100,6 @@ jobs:
           name: upload to pypi
           command: |
             . venv/bin/activate
+            cd api/python
             pip install twine
             twine upload dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(\-[a-ZA-Z])*/
+              only: /[0-9]+(\.[0-9]+)*(\-[a-z])*/
             branches:
               ignore: /.*/
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*[-a-z]+/
+              only: /[0-9]+(\.[0-9]+)*/
 jobs:
   test-3.6: &test-template
     docker:
@@ -67,7 +67,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "api/pythonsetup.py" }}-{{ checksum "Makefile" }}
+          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,9 @@ jobs:
       - run:
           name: create packages
           command: |
-            python api/python/setup.py sdist
-            python api/python/setup.py bdist_wheel
+            cd api/python
+            python setup.py sdist
+            python setup.py bdist_wheel
       - run:
           name: upload to pypi
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,20 @@ workflows:
   test:
     jobs:
       - test-3.6
-
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
 jobs:
   test-3.6: &test-template
     docker:
@@ -24,3 +37,42 @@ jobs:
             . venv/bin/activate
             cd api/python && pytest --cov=./
             codecov
+  deploy:
+    docker:
+      - image: circleci/python:3.6-jessie
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -e api/python[tests]
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          paths:
+            - "venv"
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            python setup.py verify
+      - run:
+          name: init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = quiltdata" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: create packages
+          command: |
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: upload to pypi
+          command: |
+            . venv/bin/activate
+            twine upload dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ workflows:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
 jobs:
   test-3.6: &test-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -51,7 +51,7 @@ jobs:
             . venv/bin/activate
             pip install -e api/python[tests]
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:
@@ -69,7 +69,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v1-dependency-cache-{{ checksum "api/pythonsetup.py" }}-{{ checksum "Makefile" }}
       - run:
           name: install python dependencies
           command: |
@@ -77,7 +77,7 @@ jobs:
             . venv/bin/activate
             pip install -e api/python[tests]
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "setup.py" }}-{{ checksum "Makefile" }}
+          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
           paths:
             - "venv"
       - run:
@@ -85,7 +85,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            python setup.py verify
+            python api/python/setup.py verify
       - run:
           name: init .pypirc
           command: |
@@ -95,8 +95,8 @@ jobs:
       - run:
           name: create packages
           command: |
-            python setup.py sdist
-            python setup.py bdist_wheel
+            python api/python/setup.py sdist
+            python api/python/setup.py bdist_wheel
       - run:
           name: upload to pypi
           command: |

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -26,7 +26,7 @@ class VerifyVersionCommand(install):
 
 setup(
     name="t4",
-    version="0.0.2-dev",
+    version="0.0.1",
     packages=find_packages(),
     description='T4',
     long_description=readme(),

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.0.1"
+VERSION = "0.0.3"
 
 def readme():
     readme_short = """

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -26,7 +26,7 @@ class VerifyVersionCommand(install):
 
 setup(
     name="t4",
-    version="0.0.1",
+    version="0.0.3",
     packages=find_packages(),
     description='T4',
     long_description=readme(),

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -8,6 +8,12 @@ VERSION = "0.0.3"
 
 def readme():
     readme_short = """
+    Quilt T4 is a data management tool designed for data discoverability, data dependency
+    management, and data version control using `data packages <https://blog.quiltdata.com/data-packages-for-fast-reproducible-python-analysis-c74b78015c7f>`_.
+
+    The `t4` PyPi package allows you to build, push, and pull data packages in T4 using Python.
+    Visit the GitHub `repository <https://github.com/quiltdata/t4>`_ for more information.
+
     """
     return readme_short
 
@@ -26,7 +32,7 @@ class VerifyVersionCommand(install):
 
 setup(
     name="t4",
-    version="0.0.3",
+    version=VERSION,
     packages=find_packages(),
     description='T4',
     long_description=readme(),

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -1,9 +1,28 @@
+import os
+import sys
+
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+VERSION = "0.0.1"
 
 def readme():
     readme_short = """
     """
     return readme_short
+
+class VerifyVersionCommand(install):
+    """Custom command to verify that the git tag matches our version"""
+    description = 'verify that the git tag matches our version'
+
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
 
 setup(
     name="t4",
@@ -59,5 +78,8 @@ setup(
     include_package_data=True,
     entry_points={
         # 'console_scripts': ['quilt=quilt.tools.main:main'],
-    }
+    },
+    cmdclass={
+        'verify': VerifyVersionCommand,
+    }    
 )

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -12,7 +12,7 @@ def readme():
     management, and data version control using `data packages <https://blog.quiltdata.com/data-packages-for-fast-reproducible-python-analysis-c74b78015c7f>`_.
 
     The `t4` PyPi package allows you to build, push, and pull data packages in T4 using Python.
-    Visit the GitHub `repository <https://github.com/quiltdata/t4>`_ for more information.
+    Visit the `documentation quickstart <https://quiltdocs.gitbook.io/t4/quickstart>`_ for more information.
 
     """
     return readme_short

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -26,7 +26,7 @@ class VerifyVersionCommand(install):
 
 setup(
     name="t4",
-    version="0.0.1-dev",
+    version="0.0.2-dev",
     packages=find_packages(),
     description='T4',
     long_description=readme(),

--- a/api/python/t4/LICENSE
+++ b/api/python/t4/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Add a circleci workflow to update PyPi backages based on git tag commands. Added a function to verify that the git tag matches the pypi version in `setup.py`

To cut a release:

1. Update the version in `setup.py`
2. `git tag $VERSION`
3. `git push --tags`

