### PR TITLE
Update README and correct docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ T4 is alpha software. It is not yet recommended for production use.
 * Every file in T4 is versioned and searchable
 * T4 is for data scientists, data engineers, and data-driven teams
 
-![](docs/imgs/t4.gif)
+![](https://github.com/quiltdata/t4/blob/master/docs/imgs/t4.gif?raw=true)
 
 ### Use cases
 * Collaborate - get everyone on the same page by pointing them all to the same immutable data version
@@ -34,16 +34,11 @@ T4 is alpha software. It is not yet recommended for production use.
 * Read/write Python objects to and from S3
 * Immutable versions for objects, immutable packages for collections of objects
 
-## Known limitations of the Alpha Preview
-
-* Web catalog supports only one bucket (temporary limitation)
-
 ## Components
 
 * `/catalog` (JavaScript) - Search, browse, and preview your data in S3
 * `/api/python` - Read, write, and annotate Python objects in S3
 
 ## Documentation
-* [User docs](./UserDocs.md)
-* [Developer docs](./DeveloperDocs.md)
-* [Roadmap](./Roadmap.md)
+* [Docs](https://quiltdocs.gitbook.io/t4/)
+* [Roadmap](https://github.com/quiltdata/t4/blob/master/Roadmap.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 	* /README.md and docs/README.md should be identical copies (symlinks don't work)
 	* Use only *absolute links* in these files. Relative links will break.
 !-->
-[![docs on_gitbook](https://img.shields.io/badge/docs-on_gitbook-blue.svg?style=flat-square)](https://docs.quiltdata.com/)
+[![docs on_gitbook](https://img.shields.io/badge/docs-on_gitbook-blue.svg?style=flat-square)](https://quiltdocs.gitbook.io/t4/)
 [![chat on_slack](https://img.shields.io/badge/chat-on_slack-blue.svg?style=flat-square)](https://slack.quiltdata.com/)
 [![codecov](https://codecov.io/gh/quiltdata/t4/branch/master/graph/badge.svg)](https://codecov.io/gh/quiltdata/t4)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ T4 is alpha software. It is not yet recommended for production use.
 * Every file in T4 is versioned and searchable
 * T4 is for data scientists, data engineers, and data-driven teams
 
-![](docs/imgs/t4.gif)
+![](https://github.com/quiltdata/t4/blob/master/docs/imgs/t4.gif?raw=true)
 
 ### Use cases
 * Collaborate - get everyone on the same page by pointing them all to the same immutable data version
@@ -34,16 +34,11 @@ T4 is alpha software. It is not yet recommended for production use.
 * Read/write Python objects to and from S3
 * Immutable versions for objects, immutable packages for collections of objects
 
-## Known limitations of the Alpha Preview
-
-* Web catalog supports only one bucket (temporary limitation)
-
 ## Components
 
 * `/catalog` (JavaScript) - Search, browse, and preview your data in S3
 * `/api/python` - Read, write, and annotate Python objects in S3
 
 ## Documentation
-* [User docs](./UserDocs.md)
-* [Developer docs](./DeveloperDocs.md)
-* [Roadmap](./Roadmap.md)
+* [Docs](https://quiltdocs.gitbook.io/t4/)
+* [Roadmap](https://github.com/quiltdata/t4/blob/master/Roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 	* /README.md and docs/README.md should be identical copies (symlinks don't work)
 	* Use only *absolute links* in these files. Relative links will break.
 !-->
-[![docs on_gitbook](https://img.shields.io/badge/docs-on_gitbook-blue.svg?style=flat-square)](https://docs.quiltdata.com/)
+[![docs on_gitbook](https://img.shields.io/badge/docs-on_gitbook-blue.svg?style=flat-square)](https://quiltdocs.gitbook.io/t4/)
 [![chat on_slack](https://img.shields.io/badge/chat-on_slack-blue.svg?style=flat-square)](https://slack.quiltdata.com/)
 [![codecov](https://codecov.io/gh/quiltdata/t4/branch/master/graph/badge.svg)](https://codecov.io/gh/quiltdata/t4)
 


### PR DESCRIPTION
Updates the README to remove some cruft, and use absolute links instead of relative links to properly sync `README.md` and `docs/README.md`.