### PR TITLE
Make package physical keys a singleton

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -34,24 +34,6 @@ def hash_file(readable_file):
 
     return hasher.hexdigest()
 
-def _to_singleton(physical_keys):
-    """
-    Ensure that there is a single physical key, throw otherwise.
-    Temporary utility method to avoid repeated, identical checks.
-
-    Args:
-        pkeys (list): list of physical keys
-    Returns:
-        A physical key
-
-    Throws:
-        NotImplementedError
-    """
-    # TODO: temp shim
-    if isinstance(physical_keys, list):
-        return physical_keys[0]
-    else:
-        return physical_keys
 
 def get_package_registry(path=None):
     """ Returns the package registry root for a given path """
@@ -172,7 +154,7 @@ class PackageEntry(object):
         """
         Returns the physical key of this PackageEntry.
         """
-        return _to_singleton(self.physical_key)
+        return self.physical_key
 
     def deserialize(self):
         """
@@ -195,8 +177,7 @@ class PackageEntry(object):
         except ValueError:
             raise QuiltException("Unknown serialization target: %r" % target_str)
 
-        physical_key = _to_singleton(self.physical_key)
-        data, _ = get_bytes(physical_key)
+        data, _ = get_bytes(self.physical_key)
         self._verify_hash(data)
 
         return deserialize_obj(data, target)
@@ -211,9 +192,8 @@ class PackageEntry(object):
         Returns:
             None
         """
-        physical_key = _to_singleton(self.physical_key)
         dest = fix_url(dest)
-        copy_file(physical_key, dest, self.meta)
+        copy_file(self.physical_key, dest, self.meta)
 
     def __call__(self):
         """
@@ -866,7 +846,7 @@ class Package(object):
         # Since all that is modified is physical keys, pkg will have the same top hash
         for logical_key, entry in self.walk():
             # Copy the datafiles in the package.
-            physical_key = _to_singleton(entry.physical_key)
+            physical_key = entry.physical_key
             new_physical_key = dest_url + "/" + quote(logical_key)
             versioned_key = copy_file(physical_key, new_physical_key, entry.meta)
 

--- a/api/python/tests/integration/data/.quilt/packages/20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733
+++ b/api/python/tests/integration/data/.quilt/packages/20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733
@@ -1,3 +1,3 @@
-{"version": "v0", "top_hash": {"alg": "v0", "value": "20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733"}}
-{"logical_key": "a.txt", "physical_keys": ["file:///home/dima/src/t4/api/python/tmp/a.txt"], "size": 13, "hash": {"type": "SHA256", "value": "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d"}, "meta": {"user_meta": {"x": "y"}}}
-{"logical_key": "b/x.json", "physical_keys": ["file:///home/dima/src/t4/api/python/tmp/b/x.json"], "size": 14, "hash": {"type": "SHA256", "value": "426fc04f04bf8fdb5831dc37bbb6dcf70f63a37e05a68c6ea5f63e85ae579376"}, "meta": {}}
+{"version": "v0", "top_hash": {"alg": "v1", "value": "20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733"}}
+{"logical_key": "a.txt", "physical_key": "file:///home/dima/src/t4/api/python/tmp/a.txt", "size": 13, "hash": {"type": "SHA256", "value": "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d"}, "meta": {"user_meta": {"x": "y"}}}
+{"logical_key": "b/x.json", "physical_key": "file:///home/dima/src/t4/api/python/tmp/b/x.json", "size": 14, "hash": {"type": "SHA256", "value": "426fc04f04bf8fdb5831dc37bbb6dcf70f63a37e05a68c6ea5f63e85ae579376"}, "meta": {}}

--- a/api/python/tests/integration/data/local_manifest.jsonl
+++ b/api/python/tests/integration/data/local_manifest.jsonl
@@ -1,5 +1,5 @@
 {"semver": "1.1.1","comment": "example schema","quilt_schema_version": "0.0.1"}
-{"logical_key":"foo","physical_keys":["file:///foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"bar.csv","physical_keys":["file:///bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"baz/bat","physical_keys":["file:///User/home/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"my_data_pkg/data_frames/","physical_keys":["s3://my_bucket/my_data_pkg/data_frames/"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"foo","physical_key":"file:///foo","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"bar.csv","physical_key":"file:///bar.csv","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"baz/bat","physical_key":"file:///User/home/baz/bat","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"my_data_pkg/data_frames/","physical_key":"s3://my_bucket/my_data_pkg/data_frames/","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}

--- a/api/python/tests/integration/data/t4_manifest.jsonl
+++ b/api/python/tests/integration/data/t4_manifest.jsonl
@@ -1,5 +1,5 @@
 {"semver": "1.1.1","comment": "example schema","quilt_schema_version": "0.0.1"}
-{"logical_key":"foo","physical_keys":["s3://my_bucket/my_data_pkg/foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"bar.csv","physical_keys":["s3://my_bucket/my_data_pkg/bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"baz/bat","physical_keys":["s3://my_bucket/my_data_pkg/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"my_data_pkg/data_frames/","physical_keys":["s3://my_bucket/my_data_pkg/data_frames/"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"foo","physical_key":"s3://my_bucket/my_data_pkg/foo","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"bar.csv","physical_key":"s3://my_bucket/my_data_pkg/bar.csv","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"baz/bat","physical_key":"s3://my_bucket/my_data_pkg/baz/bat","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
+{"logical_key":"my_data_pkg/data_frames/","physical_key":"s3://my_bucket/my_data_pkg/data_frames/","hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -53,7 +53,7 @@ def test_build(tmpdir):
     out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
     with open(out_path) as fd:
         pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
+        assert test_file.resolve().as_uri() == pkg['foo'].physical_key
 
     # Verify latest points to the new location.
     named_pointer_path = Path(BASE_PATH, ".quilt/named_packages/Quilt/Test/latest")
@@ -67,7 +67,7 @@ def test_build(tmpdir):
     out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
     with open(out_path) as fd:
         pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+        assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
 
 def test_read_manifest(tmpdir):
@@ -79,7 +79,7 @@ def test_read_manifest(tmpdir):
     with open(out_path, 'w') as fd:
         pkg.dump(fd)
     
-    # Insepct the jsonl to verify everything is maintained, i.e.
+    # Inspect the jsonl to verify everything is maintained, i.e.
     # that load/dump results in an equivalent set.
     # todo: Use load/dump once __eq__ implemented.
     with open(LOCAL_MANIFEST) as fd:
@@ -277,20 +277,20 @@ def test_local_set_dir(tmpdir):
 
     pkg = pkg.set_dir("/", ".")
 
-    assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
-    assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_keys[0]
-    assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_keys[0]
+    assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_key
+    assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_key
+    assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_key
+    assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_key
 
     pkg = Package()
     pkg = pkg.set_dir('/','foo_dir/baz_dir/')
     # todo nested at set_dir site or relative to set_dir path.
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_keys[0]
+    assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_key
 
     pkg = Package()
     pkg = pkg.set_dir('my_keys', 'foo_dir/baz_dir/')
     # todo nested at set_dir site or relative to set_dir path.
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_keys[0]
+    assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_key
 
 
 def test_s3_set_dir(tmpdir):
@@ -306,8 +306,8 @@ def test_s3_set_dir(tmpdir):
 
         pkg.set_dir('', 's3://bucket/foo/')
 
-        assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-        assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+        assert pkg['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
+        assert pkg['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
 
         list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
@@ -315,8 +315,8 @@ def test_s3_set_dir(tmpdir):
 
         pkg.set_dir('bar', 's3://bucket/foo')
 
-        assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-        assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+        assert pkg['bar']['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
+        assert pkg['bar']['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
 
         list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
@@ -341,7 +341,7 @@ def test_updates(tmpdir):
         fd.write('test_file_content_string')
         test_file = Path(fd.name)
     pkg = pkg.update({'bar': 'bar.txt'})
-    assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+    assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
     assert pkg['foo']() == '123\n'
 
@@ -350,7 +350,7 @@ def test_updates(tmpdir):
         fd.write('test_file_content_string')
         test_file = Path(fd.name)
     pkg = pkg.update({'baz': 'baz.txt'}, prefix='prefix/')
-    assert test_file.resolve().as_uri() == pkg['prefix/baz'].physical_keys[0]
+    assert test_file.resolve().as_uri() == pkg['prefix/baz'].physical_key
 
     assert pkg['foo']() == '123\n'
 
@@ -421,7 +421,7 @@ def test_set_package_entry(tmpdir):
         test_file = Path(fd.name)
     pkg['bar'].set('bar.txt')
 
-    assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+    assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
 def test_tophash_changes(tmpdir):
     test_file = tmpdir / 'test.txt'


### PR DESCRIPTION
Per discussion ([circa one month ago](https://quiltdata.slack.com/archives/C3A5VP2MP/p1542241721023800)) we agreed that package physical keys, which are currently a list, should become a singleton.

This PR refactors the package manifest format to match this new pattern. It also bumps the `"version": "v0"` reference at the top of the manifest to `"version": "v1"`.

This PR does _not_ do something else that was also proposed, but also still needs to be implemented: hanging the package metadata off of a `'/'` key in the manifest file, instead of having it live on its own special line at the top of the manifest file. That is left for a future PR.