### PR TITLE
Fix upload_file for large_files

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -363,7 +363,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
         src_etag_list = list(src_etag_iter)
 
     with tqdm(total=total_size, unit='B', unit_scale=True) as progress:
-        callback = ProgressCallback(progress)               
+        callback = ProgressCallback(progress)
 
         if is_dir:
             futures = []
@@ -416,7 +416,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
                             if version_id != 'null':  # Yes, 'null'
                                 obj_url += '?versionId=%s' % quote(version_id)
                                 versioned_key[0] = obj_url
-                    return cb                
+                    return cb
                 if override_meta is None:
                     meta = _parse_file_metadata(f)
                 else:

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -364,46 +364,76 @@ def upload_file(src_path, bucket, key, override_meta=None):
         src_etag_list = list(src_etag_iter)
 
     with tqdm(total=total_size, unit='B', unit_scale=True) as progress:
-        callback = ProgressCallback(progress)
+        callback = ProgressCallback(progress)               
 
-        futures = []
-        for f, etag in zip(src_file_list, src_etag_list):
-            real_dest_path = key + str(f.relative_to(src_root)) if (not key or key.endswith('/')) else key
+        if is_dir:
+            futures = []
+            for f, etag in zip(src_file_list, src_etag_list):
+                real_dest_path = key + str(f.relative_to(src_root)) if (not key or key.endswith('/')) else key
+                if override_meta is None:
+                    meta = _parse_file_metadata(f)
+                else:
+                    meta = override_meta
 
-            if override_meta is None:
-                meta = _parse_file_metadata(f)
+                extra_args = dict(Metadata={HELIUM_METADATA: json.dumps(meta)})
+                existing_src = existing_etags.get(etag)
+                if existing_src is not None:
+                    # We found an existing object with the same ETag, so copy it instead of uploading
+                    # the bytes. (In the common case, it's the same key - the object is already there -
+                    # but we still copy it onto itself just in case the metadata has changed.)
+                    extra_args['MetadataDirective'] = 'REPLACE'
+                    future = s3_manager.copy(
+                        dict(Bucket=bucket, Key=existing_src[0], VersionId=existing_src[1]),
+                        bucket, real_dest_path, extra_args, [callback]
+                    )
+                else:
+                    # Upload the file.
+                    future = s3_manager.upload(str(f), bucket, real_dest_path, extra_args, [callback])
+                futures.append(future)
+
+            for future in futures:
+                future.result()
+        else:
+            if total_size < s3_transfer_config.multipart_threshold:
+                def meta_callback(bucket, key, versioned_key):
+                    def cb(resp):
+                        version_id = resp.get('VersionId', 'null')  # Absent in unversioned buckets.
+                        if versioned_key is not None:
+                            obj_url = 's3://%s/%s' % (bucket, key)
+                            if version_id != 'null':  # Yes, 'null'
+                                obj_url += '?versionId=%s' % quote(version_id)
+                                versioned_key[0] = obj_url
+                    return cb
+                f = src_file_list[0]
+                if override_meta is None:
+                    meta = _parse_file_metadata(f)
+                else:
+                    meta = override_meta
+                extra_args = dict(Metadata={HELIUM_METADATA: json.dumps(meta)},
+                                  Callback=meta_callback(bucket, key, versioned_key))
+                s3_manager.upload(str(f), bucket, key, extra_args, [callback])
             else:
-                meta = override_meta
-
-            def meta_callback(bucket, real_dest_path, versioned_key):
-                def cb(resp):
-                    version_id = resp.get('VersionId', 'null')  # Absent in unversioned buckets.
-                    if versioned_key is not None:
-                        obj_url = 's3://%s/%s' % (bucket, real_dest_path)
-                        if version_id != 'null':  # Yes, 'null'
-                            obj_url += '?versionId=%s' % quote(version_id)
-                        versioned_key[0] = obj_url
-                return cb
-
-            extra_args = dict(Metadata={HELIUM_METADATA: json.dumps(meta)},
-                              Callback=meta_callback(bucket, real_dest_path, versioned_key))
-            existing_src = existing_etags.get(etag)
-            if existing_src is not None:
-                # We found an existing object with the same ETag, so copy it instead of uploading
-                # the bytes. (In the common case, it's the same key - the object is already there -
-                # but we still copy it onto itself just in case the metadata has changed.)
-                extra_args['MetadataDirective'] = 'REPLACE'
-                future = s3_manager.copy(
-                    dict(Bucket=bucket, Key=existing_src[0], VersionId=existing_src[1]),
-                    bucket, real_dest_path, extra_args, [callback]
-                )
-            else:
-                # Upload the file.
-                future = s3_manager.upload(str(f), bucket, real_dest_path, extra_args, [callback])
-            futures.append(future)
-
-        for future in futures:
-            future.result()
+                response = s3_client.create_multipart_upload(Bucket=bucket, Key=key)
+                parts = []
+                with open(src_file_list[0], 'rb') as f:
+                    i = 1
+                    while True:
+                        chunk = f.read(s3_transfer_config.multipart_threshold)
+                        if not len(chunk):
+                            break
+                        part = s3_client.upload_part(Body=chunk,
+                                                     Bucket=bucket,
+                                                     Key=key,
+                                                     UploadId=response['UploadId'],
+                                                     PartNumber=i)
+                        parts.append({"PartNumber": i, "ETag": part["ETag"]})
+                        progress.update(len(chunk))
+                        i += 1
+                result = s3_client.complete_multipart_upload(Bucket=bucket,
+                                                             Key=key,
+                                                             UploadId=response['UploadId'],
+                                                             MultipartUpload={"Parts": parts})
+                versioned_key[0] = result['VersionId']
     return versioned_key
 
 def delete_object(bucket, key):

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -2,6 +2,7 @@ from codecs import iterdecode
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 import hashlib
+import itertools
 import json
 import pathlib
 import platform
@@ -427,8 +428,7 @@ def upload_file(src_path, bucket, key, override_meta=None):
                 response = s3_client.create_multipart_upload(Bucket=bucket, Key=key)
                 parts = []
                 with open(f, 'rb') as f:
-                    i = 1
-                    while True:
+                    for i in itertools.count(1):
                         chunk = f.read(s3_transfer_config.multipart_threshold)
                         if not len(chunk):
                             break
@@ -439,7 +439,6 @@ def upload_file(src_path, bucket, key, override_meta=None):
                                                      PartNumber=i)
                         parts.append({"PartNumber": i, "ETag": part["ETag"]})
                         progress.update(len(chunk))
-                        i += 1
                 result = s3_client.complete_multipart_upload(Bucket=bucket,
                                                              Key=key,
                                                              UploadId=response['UploadId'],


### PR DESCRIPTION
## Description
Passing a callback to grab the VersionId works for single-part uploads (put_file), but not multi-part uploads. This PR adds a separate codepath for single-file uploads (i.e. not directories) that checks the file size and uses a multi-part upload for large files. It grabs the VersionId from `complete_multipart_upload`. There is likely an opportunity to speedup large-file uploads by parallelizing the uploading of the separate parts, but I'm saving that for a future PR.