### PR TITLE
Use lastest node runtime

### DIFF
--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -231,7 +231,7 @@ Resources:
             }
           };
       Timeout: 30
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
 
   # API
 


### PR DESCRIPTION
Tested while spinning up `t4-staging` stack, everything looks normal