### PR TITLE
Implement a .quiltignore feature

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -550,8 +550,7 @@ class Package(object):
             ignore = src_path / '.quiltignore'
             if ignore.exists():
                 ignore_rules = ignore.read_text('utf-8').split("\n")
-                filenames = [f.name for f in src_path.rglob('*')]
-                files = quiltignore_filter(src_path.rglob('*'), ignore_rules, 'file')
+                files = quiltignore_filter(files, ignore_rules, 'file')
 
             for f in files:
                 if not f.is_file():
@@ -561,7 +560,6 @@ class Package(object):
                 # TODO: Warn if overwritting a logical key?
                 root.set(logical_key, entry)
         elif url.scheme == 's3':
-            import pdb; pdb.set_trace()
             src_bucket, src_key, src_version = parse_s3_url(url)
             if src_version:
                 raise PackageException("Directories cannot have versions")

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -545,7 +545,6 @@ class Package(object):
             if not src_path.is_dir():
                 raise PackageException("The specified directory doesn't exist")
 
-            # TODO: keep working on this ignore rules code
             files = src_path.rglob('*')
             ignore = src_path / '.quiltignore'
             if ignore.exists():

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -21,7 +21,7 @@ from .data_transfer import (
 from .exceptions import PackageException
 from .util import (
     QuiltException, BASE_PATH, fix_url, get_local_registry, get_remote_registry,
-    parse_file_url, parse_s3_url, validate_package_name
+    parse_file_url, parse_s3_url, validate_package_name, quiltignore_filter
 )
 
 
@@ -544,7 +544,15 @@ class Package(object):
             src_path = pathlib.Path(parse_file_url(url))
             if not src_path.is_dir():
                 raise PackageException("The specified directory doesn't exist")
+
+            # TODO: keep working on this ignore rules code
             files = src_path.rglob('*')
+            ignore = src_path / '.quiltignore'
+            if ignore.exists():
+                ignore_rules = ignore.read_text('utf-8').split("\n")
+                filenames = [f.name for f in src_path.rglob('*')]
+                files = quiltignore_filter(src_path.rglob('*'), ignore_rules, 'file')
+
             for f in files:
                 if not f.is_file():
                     continue
@@ -553,6 +561,7 @@ class Package(object):
                 # TODO: Warn if overwritting a logical key?
                 root.set(logical_key, entry)
         elif url.scheme == 's3':
+            import pdb; pdb.set_trace()
             src_bucket, src_key, src_version = parse_s3_url(url)
             if src_version:
                 raise PackageException("Directories cannot have versions")

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -247,6 +247,16 @@ def get_remote_registry():
 
 
 def quiltignore_filter(paths, ignore_rules, url_scheme):
+    """Given a list paths, filter out the paths which are captured by the given
+    ignore rules.
+
+    Args:
+        paths (list): a list or iterable of paths
+        ignore_rules (list): a list or iterable of ignore rules, in Unix shell
+            style wildcard format
+        url_scheme (str): the URL scheme, only the "file" scheme is currently
+            supported
+    """
     if url_scheme == 'file':
         from fnmatch import fnmatch
 
@@ -259,10 +269,14 @@ def quiltignore_filter(paths, ignore_rules, url_scheme):
 
         for ignore_rule in ignore_rules:
             ignore_rule = os.getcwd() + '/' + ignore_rule
-            files = set(n for n in files if not fnmatch(n, ignore_rule))
-            dirs = set(n for n in dirs if not fnmatch(n.as_posix() + "/", ignore_rule))
 
-        import pdb; pdb.set_trace()
+            for dir in dirs:
+                if fnmatch(dir.as_posix() + "/", ignore_rule):
+                    files = set(n for n in files if dir not in n.parents)
+                    dirs = dirs - {dir}
+
+            files = set(n for n in files if not fnmatch(n, ignore_rule))
+
         return files.union(dirs)
     else:
         raise NotImplementedError

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -273,13 +273,13 @@ def quiltignore_filter(paths, ignore_rules, url_scheme):
             if dirs:
                 dir_idx = 0
                 while True:
-                    dir = dirs[dir_idx]
+                    pkg_dir = dirs[dir_idx]
 
                     # copy git behavior --- git matches paths and directories equivalently.
                     # e.g. both foo and foo/ will match the ignore rule "foo"
                     # but only foo/ will match the ignore rule "foo/"
-                    if fnmatch(dir.as_posix() + "/", ignore_rule) or fnmatch(dir.as_posix(), ignore_rule):
-                        files = set(n for n in files if dir not in n.parents)
+                    if fnmatch(pkg_dir.as_posix() + "/", ignore_rule) or fnmatch(pkg_dir.as_posix(), ignore_rule):
+                        files = set(n for n in files if pkg_dir not in n.parents)
                         dirs = dirs[:dir_idx] + dirs[dir_idx + 1:]
                     else:
                         dir_idx += 1

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -246,18 +246,23 @@ def get_remote_registry():
     return load_config().get('default_remote_registry', None)
 
 
-def quiltignore_filter(filenames, ignore_rules, url_scheme):
-    from fnmatch import fnmatch
-
+def quiltignore_filter(paths, ignore_rules, url_scheme):
     if url_scheme == 'file':
-        for ignore in ignore_rules:
-            if ignore == 'ay':
-                import pdb; pdb.set_trace()
+        from fnmatch import fnmatch
 
-            filenames = [n for n in filenames if not fnmatch(n, ignore)]
-        return filenames
-    elif url_scheme == 's3':
-        # TODO
-        raise NotImplementedError
+        files, dirs = set(), set()
+        for path in paths:
+            if path.is_file():
+                files.add(path)
+            else:
+                dirs.add(path)
+
+        for ignore_rule in ignore_rules:
+            ignore_rule = os.getcwd() + '/' + ignore_rule
+            files = set(n for n in files if not fnmatch(n, ignore_rule))
+            dirs = set(n for n in dirs if not fnmatch(n.as_posix() + "/", ignore_rule))
+
+        import pdb; pdb.set_trace()
+        return files.union(dirs)
     else:
         raise NotImplementedError

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -271,7 +271,10 @@ def quiltignore_filter(paths, ignore_rules, url_scheme):
             ignore_rule = os.getcwd() + '/' + ignore_rule
 
             for dir in dirs:
-                if fnmatch(dir.as_posix() + "/", ignore_rule):
+                # copy git behavior --- git matches paths and directories equivalently.
+                # e.g. both foo and foo/ will match the ignore rule "foo"
+                # but only foo/ will match the ignore rule "foo/"
+                if fnmatch(dir.as_posix() + "/", ignore_rule) or fnmatch(dir.as_posix(), ignore_rule):
                     files = set(n for n in files if dir not in n.parents)
                     dirs = dirs - {dir}
 

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -244,3 +244,20 @@ def get_local_registry():
 
 def get_remote_registry():
     return load_config().get('default_remote_registry', None)
+
+
+def quiltignore_filter(filenames, ignore_rules, url_scheme):
+    from fnmatch import fnmatch
+
+    if url_scheme == 'file':
+        for ignore in ignore_rules:
+            if ignore == 'ay':
+                import pdb; pdb.set_trace()
+
+            filenames = [n for n in filenames if not fnmatch(n, ignore)]
+        return filenames
+    elif url_scheme == 's3':
+        # TODO
+        raise NotImplementedError
+    else:
+        raise NotImplementedError

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -347,6 +347,22 @@ def test_local_set_dir(tmpdir):
     # todo nested at set_dir site or relative to set_dir path.
     assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_keys[0]
 
+    # Verify ignoring files in the presence of a dot-quiltignore
+    with open('.quiltignore', 'w') as fd:
+        fd.write('foo\nbar')
+
+    pkg = Package()
+    pkg = pkg.set_dir("/", ".")
+    assert 'foo_dir' in pkg.keys()
+    assert 'foo' not in pkg.keys() and 'bar' not in pkg.keys()
+
+    with open('.quiltignore', 'w') as fd:
+        fd.write('foo_dir')
+
+    pkg = Package()
+    pkg = pkg.set_dir("/", ".")
+    assert 'foo_dir' not in pkg.keys()
+
 
 def test_s3_set_dir(tmpdir):
     """ Verify building a package from an S3 directory. """

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -349,7 +349,8 @@ def test_local_set_dir(tmpdir):
 
     # Verify ignoring files in the presence of a dot-quiltignore
     with open('.quiltignore', 'w') as fd:
-        fd.write('foo\nbar')
+        fd.write('foo\n')
+        fd.write('bar')
 
     pkg = Package()
     pkg = pkg.set_dir("/", ".")
@@ -362,6 +363,14 @@ def test_local_set_dir(tmpdir):
     pkg = Package()
     pkg = pkg.set_dir("/", ".")
     assert 'foo_dir' not in pkg.keys()
+
+    with open('.quiltignore', 'w') as fd:
+        fd.write('foo_dir\n')
+        fd.write('foo_dir/baz_dir')
+
+    pkg = Package()
+    pkg = pkg.set_dir("/", ".")
+    assert 'foo_dir/baz_dir' not in pkg.keys() and 'foo_dir' not in pkg.keys()
 
 
 def test_s3_set_dir(tmpdir):


### PR DESCRIPTION
Currently when you call `t4.Package.set_dir` you drop _all_ of the files in the current directory into the package. This is inconvenient because it will include files that you probably don't want to include in the package, like `.git`, `.DS_Store`, etcetera.

Also `t4` best practice is managing parts of the project folders you end up with using `t4` and parts of it using `git` et al. If we don't support a conventional `.gitignore` equivalent we make it a lot harder for users to snapshot and sync their projects quickly, they would have to run `set` file-by-file. This feature has been on my radar for a while now, and here's an implementation.