### PR TITLE
Re-implement the upload/download/copy code.

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -312,6 +312,10 @@ def _copy_remote_file(callback, size, src_bucket, src_key, src_version, dest_buc
 
 
 def _copy_file_list_internal(file_list):
+    """
+    Takes a list of tuples (src, dest, size, override_meta) and copies the data in parallel.
+    Returns versioned URLs for S3 destinations and regular file URLs for files.
+    """
     total_size = sum(size for _, _, size, _ in file_list)
 
     with tqdm(desc="Copying", total=total_size, unit='B', unit_scale=True) as progress:
@@ -481,6 +485,11 @@ def _looks_like_dir(s):
 
 
 def copy_file_list(file_list):
+    """
+    Takes a list of tuples (src, dest, override_meta) and copies them in parallel.
+    URLs must be regular files, not directories.
+    Returns versioned URLs for S3 destinations and regular file URLs for files.
+    """
     def worker(args):
         src, dest, override_meta = args
 
@@ -502,6 +511,11 @@ def copy_file_list(file_list):
 
 
 def copy_file(src, dest, override_meta=None):
+    """
+    Copies a single file or directory.
+    If src is a file, dest can be a file or a directory.
+    If src is a directory, dest must be a directory.
+    """
     def sanity_check(rel_path):
         for part in rel_path.split('/'):
             if part in ('', '.', '..'):

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -3,7 +3,7 @@ from collections import Mapping, Sequence, Set, OrderedDict
 import datetime
 import json
 import os
-from urllib.parse import parse_qs, unquote, urljoin, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlencode, urljoin, urlparse, urlunparse
 from urllib.request import url2pathname
 from fnmatch import fnmatch
 
@@ -114,6 +114,14 @@ def parse_s3_url(s3_url):
     if query:
         raise ValueError("Unexpected S3 query string: %r" % s3_url.query)
     return bucket, path, version_id
+
+
+def make_s3_url(bucket, path, version_id=None):
+    params = {}
+    if version_id not in (None, 'null'):
+        params = {'versionId': version_id}
+
+    return urlunparse(('s3', bucket, quote(path), None, urlencode(params), None))
 
 
 def parse_file_url(file_url):

--- a/api/python/tests/integration/data/local_manifest.jsonl
+++ b/api/python/tests/integration/data/local_manifest.jsonl
@@ -2,4 +2,3 @@
 {"logical_key":"foo","physical_keys":["file:///foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"bar.csv","physical_keys":["file:///bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"baz/bat","physical_keys":["file:///User/home/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"my_data_pkg/data_frames/","physical_keys":["s3://my_bucket/my_data_pkg/data_frames/"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}

--- a/api/python/tests/integration/data/t4_manifest.jsonl
+++ b/api/python/tests/integration/data/t4_manifest.jsonl
@@ -2,4 +2,3 @@
 {"logical_key":"foo","physical_keys":["s3://my_bucket/my_data_pkg/foo"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"bar.csv","physical_keys":["s3://my_bucket/my_data_pkg/bar.csv"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
 {"logical_key":"baz/bat","physical_keys":["s3://my_bucket/my_data_pkg/baz/bat"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}
-{"logical_key":"my_data_pkg/data_frames/","physical_keys":["s3://my_bucket/my_data_pkg/data_frames/"],"hash":{"type":"SHA256","value":"abcd"},"size":1024,"meta":{}}

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -6,7 +6,7 @@ import shutil
 from urllib.parse import urlparse
 
 import jsonlines
-from mock import patch, call
+from mock import patch, call, ANY
 import pytest
 
 import t4
@@ -147,8 +147,7 @@ def test_materialize_from_remote(tmpdir):
     with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
         with open(REMOTE_MANIFEST) as fd:
             pkg = Package.load(fd)
-        with patch('t4.data_transfer._download_single_file', new=no_op_mock), \
-                patch('t4.data_transfer._download_dir', new=no_op_mock), \
+        with patch('t4.data_transfer._download_file'), \
                 patch('t4.Package.build', new=no_op_mock), \
                 patch('t4.packages.get_remote_registry') as config_mock:
             config_mock.return_value = tmpdir
@@ -249,53 +248,49 @@ def test_fetch(tmpdir):
 def test_load_into_t4(tmpdir):
     """ Verify loading local manifest and data into S3. """
     with patch('t4.packages.put_bytes') as bytes_mock, \
-         patch('t4.packages.copy_file') as file_mock, \
+         patch('t4.data_transfer._upload_file') as file_mock, \
          patch('t4.packages.get_remote_registry') as config_mock:
         config_mock.return_value = 's3://my_test_bucket'
         new_pkg = Package()
         # Create a dummy file to add to the package.
-        test_file = os.path.join(tmpdir, 'bar')
-        with open(test_file, 'w') as fd:
-            fd.write(test_file)
+        contents = 'blah'
+        test_file = pathlib.Path(tmpdir) / 'bar'
+        test_file.write_text(contents)
         new_pkg = new_pkg.set('foo', test_file)
-        new_pkg.push('Quilt/package_name', 's3://my_test_bucket/')
-
-        # Get the second argument (destination) from the non-keyword args list
-        bytes_dest_args = [x[0][1] for x in bytes_mock.call_args_list]
-        file_dest_args = [x[0][1] for x in file_mock.call_args_list]
+        new_pkg.push('Quilt/package', 's3://my_test_bucket/')
 
         # Manifest copied
-        assert 's3://my_test_bucket/.quilt/packages/' + new_pkg.top_hash() in bytes_dest_args
-        assert 's3://my_test_bucket/.quilt/named_packages/Quilt/package_name/latest' in bytes_dest_args
+        print(bytes_mock.call_args_list)
+        top_hash = new_pkg.top_hash()
+        bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
+        bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
 
         # Data copied
-        assert 's3://my_test_bucket/Quilt/package_name/foo' in file_dest_args
+        file_mock.assert_called_once_with(ANY, len(contents), str(test_file), 'my_test_bucket', 'Quilt/package/foo', {})
 
 def test_local_push(tmpdir):
     """ Verify loading local manifest and data into S3. """
     with patch('t4.packages.put_bytes') as bytes_mock, \
-         patch('t4.packages.copy_file') as file_mock, \
+         patch('t4.data_transfer._copy_local_file') as file_mock, \
          patch('t4.packages.get_remote_registry') as config_mock:
         config_mock.return_value = tmpdir / 'package_contents'
         new_pkg = Package()
-        test_file = os.path.join(tmpdir, 'bar')
-        with open(test_file, 'w') as fd:
-            fd.write(test_file)
+        contents = 'blah'
+        test_file = pathlib.Path(tmpdir) / 'bar'
+        test_file.write_text(contents)
         new_pkg = new_pkg.set('foo', test_file)
         new_pkg.push('Quilt/package', tmpdir / 'package_contents')
 
         push_uri = pathlib.Path(tmpdir, 'package_contents').as_uri()
 
-        # Get the second argument (destination) from the non-keyword args list
-        bytes_dest_args = [x[0][1] for x in bytes_mock.call_args_list]
-        file_dest_args = [x[0][1] for x in file_mock.call_args_list]
-
         # Manifest copied
-        assert push_uri + '/.quilt/packages/' + new_pkg.top_hash() in bytes_dest_args
-        assert push_uri + '/.quilt/named_packages/Quilt/package/latest' in bytes_dest_args
+        top_hash = new_pkg.top_hash()
+        bytes_mock.assert_any_call(top_hash.encode(), push_uri + '/.quilt/named_packages/Quilt/package/latest')
+        bytes_mock.assert_any_call(ANY, push_uri + '/.quilt/packages/' + top_hash)
 
         # Data copied
-        assert push_uri + '/Quilt/package/foo' in file_dest_args
+        file_mock.assert_called_once_with(ANY, len(contents), str(test_file), str(tmpdir / 'package_contents/Quilt/package/foo'), {})
+
 
 def test_package_deserialize(tmpdir):
     """ Verify loading data from a local file. """
@@ -773,8 +768,7 @@ def test_commit_message_on_push(tmpdir):
     with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
         with open(REMOTE_MANIFEST) as fd:
             pkg = Package.load(fd)
-        with patch('t4.data_transfer._download_single_file', new=no_op_mock), \
-                patch('t4.data_transfer._download_dir', new=no_op_mock), \
+        with patch('t4.data_transfer._download_file'), \
                 patch('t4.Package.build', new=no_op_mock), \
                 patch('t4.packages.get_remote_registry') as config_mock:
             config_mock.return_value = BASE_DIR

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -260,7 +260,6 @@ def test_load_into_t4(tmpdir):
         new_pkg.push('Quilt/package', 's3://my_test_bucket/')
 
         # Manifest copied
-        print(bytes_mock.call_args_list)
         top_hash = new_pkg.top_hash()
         bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
         bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)


### PR DESCRIPTION
We're no longer using the built-in S3 transfer manager, and instead implementing all the logic ourselves.
Changes:
- No more hacks to get the response metadata
- Upload/download/copy multiple sets of URLs in parallel
  - In particular, package push is parallelized
  - Local copies are also parallelized, but probably shouldn't be. TODO.
- Single progress bar for package push (well, two, actually: hashing and copying)
- Fixed versioned URLs fixed in package push

Some regressions:
- No more ETag optimization; will add it back eventually
- Progress callbacks are a bit coarse