### PR TITLE
Fix put mappings

### DIFF
--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -46,7 +46,7 @@ Mappings:
     indexer:
       hash: 5d2334a
     put-mappings:
-      hash: 76df9d0
+      hash: f5fdce0
 
 Resources:
 

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -46,7 +46,7 @@ Mappings:
     indexer:
       hash: 231cb5f
     put-mappings:
-      hash: 2c5c767
+      hash: c730ae8
 
 Resources:
 

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -44,7 +44,7 @@ Mappings:
     navigator:
       hash: 45f840e
     indexer:
-      hash: 5d2334a
+      hash: 231cb5f
     put-mappings:
       hash: f5fdce0
 

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -46,7 +46,7 @@ Mappings:
     indexer:
       hash: 231cb5f
     put-mappings:
-      hash: 74ff513
+      hash: 2c5c767
 
 Resources:
 

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -46,7 +46,7 @@ Mappings:
     indexer:
       hash: 231cb5f
     put-mappings:
-      hash: 7cb1d31
+      hash: 74ff513
 
 Resources:
 
@@ -147,7 +147,7 @@ Resources:
       ServiceToken: !GetAtt SearchMappingsLambda.Arn
       ES_HOST: !GetAtt Search.DomainEndpoint
       ES_URL: !Sub # Included for backwards compatibility (CF updates lambdas in an unhelpful way)
-        - "https://{ES_HOST}"
+        - "https://${ES_HOST}"
         - ES_HOST: !GetAtt Search.DomainEndpoint
 
   SearchMappingsLambda:

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -44,7 +44,7 @@ Mappings:
     navigator:
       hash: 45f840e
     indexer:
-      hash: 231cb5f
+      hash: 5d2334a
     put-mappings:
       hash: c730ae8
 

--- a/deployment/t4.yaml
+++ b/deployment/t4.yaml
@@ -46,7 +46,7 @@ Mappings:
     indexer:
       hash: 231cb5f
     put-mappings:
-      hash: f5fdce0
+      hash: 7cb1d31
 
 Resources:
 
@@ -146,6 +146,9 @@ Resources:
     Properties:
       ServiceToken: !GetAtt SearchMappingsLambda.Arn
       ES_HOST: !GetAtt Search.DomainEndpoint
+      ES_URL: !Sub # Included for backwards compatibility (CF updates lambdas in an unhelpful way)
+        - "https://{ES_HOST}"
+        - ES_HOST: !GetAtt Search.DomainEndpoint
 
   SearchMappingsLambda:
     Type: AWS::Lambda::Function

--- a/lambdas/es/put_mappings/put_mappings.py
+++ b/lambdas/es/put_mappings/put_mappings.py
@@ -9,6 +9,9 @@ from elasticsearch.exceptions import RequestError
 ES_INDEX = 'drive'
 
 def handler(event, context):
+    if event['RequestType'] == 'Delete':
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+        return
     try:
         es_host = event['ResourceProperties']['ES_HOST']
         session = boto3.session.Session()

--- a/lambdas/es/put_mappings/put_mappings.py
+++ b/lambdas/es/put_mappings/put_mappings.py
@@ -4,6 +4,7 @@ from aws_requests_auth.aws_auth import AWSRequestsAuth
 import boto3
 import cfnresponse
 from elasticsearch import Elasticsearch, RequestsHttpConnection
+from elasticsearch.exceptions import RequestError
 
 ES_INDEX = 'drive'
 
@@ -79,7 +80,12 @@ def handler(event, context):
             connection_class=RequestsHttpConnection
         )
 
-        es.indices.create(index=ES_INDEX, body=mappings)
+        try:
+            es.indices.create(index=ES_INDEX, body=mappings)
+        except RequestError as e:
+            print("RequestError encountered")
+            print("This is likely due to the index already existing -- nothing to worry about")
+            print(e)
 
         del event['ResourceProperties']['ServiceToken']
 

--- a/lambdas/es/put_mappings/put_mappings.py
+++ b/lambdas/es/put_mappings/put_mappings.py
@@ -9,8 +9,7 @@ ES_INDEX = 'drive'
 
 def handler(event, context):
     try:
-        es_url = event['ResourceProperties']['ES_URL']
-        es_host = es_url[8:] # clip off https://
+        es_host = event['ResourceProperties']['ES_HOST']
         session = boto3.session.Session()
 
         mappings = {


### PR DESCRIPTION
Updating the template broke put-mappings, which led to some interesting discoveries about lambda backed custom resources.

This PR hardens the template and put-mappings lambda against CloudFormation corner cases