### PR TITLE
Handle doctest code blocks, reinstate blocks in api.py

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -371,17 +371,17 @@ def config(*autoconfig_url, **config_values):
 
     To retrieve the current config, call directly, without arguments:
 
-        > import t4 as he
-        > he.config()
+        >>> import t4 as he
+        >>> he.config()
 
     To trigger autoconfiguration, call with just the navigator URL:
 
-        > he.config('https://example.com')
+        >>> he.config('https://example.com')
 
     To set config values, call with one or more key=value pairs:
 
-        > he.config(navigator_url='http://example.com',
-                    elastic_search_url='http://example.com/queries')
+        >>> he.config(navigator_url='http://example.com',
+        ...           elastic_search_url='http://example.com/queries')
 
     When setting config values, unrecognized values are rejected.  Acceptable
     config values can be found in `t4.util.CONFIG_TEMPLATE`.

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -7,17 +7,23 @@ Set or read the T4 configuration.
 
 To retrieve the current config, call directly, without arguments:
 
+```python
     >>> import t4 as he
     >>> he.config()
+```
 
 To trigger autoconfiguration, call with just the navigator URL:
 
+```python
     >>> he.config('https://example.com')
+```
 
 To set config values, call with one or more key=value pairs:
 
+```python
     >>> he.config(navigator_url='http://example.com',
     ...           elastic_search_url='http://example.com/queries')
+```
 
 When setting config values, unrecognized values are rejected.  Acceptable
 config values can be found in `t4.util.CONFIG_TEMPLATE`.

--- a/gendocs/build.py
+++ b/gendocs/build.py
@@ -13,7 +13,7 @@ from ruamel import yaml
 
 # To push out and use a new version of pydocmd to people generating docs,
 # increment this here and in the quilt pydocmd repo (setup.py and __init__.py)
-EXPECTED_VERSION_SUFFIX = '-quilt2'
+EXPECTED_VERSION_SUFFIX = '-quilt3'
 
 # Github HTTPS Revision
 # Just the branch name right now, but anything following '@' in a github repo URL


### PR DESCRIPTION
## Description
Use changes to quilt pydocmd repo, quilt branch that handle doctest-style code blocks.

```python
>>> doctest_style_blocks = (
...     'this',
...     'example',
... )
```

This includes also:
 * `api.py` has been returned to doctest-style from quote-style
 * `api.md`, updated, shows the resultant markdown changes

## Depends On
None

## TODO
