### PR TITLE
Filter returns a filtered package instead of a list of tuples

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -983,10 +983,12 @@ class Package(object):
         if include_directories:
             for lk, _ in self._walk_dir_meta():
                 if not f(lk, self[lk.rstrip("/")]):
-                    excluded_dirs = excluded_dirs.union({lk})
+                    excluded_dirs.add(lk)
 
         for lk, entity in self.walk():
-            if f(lk, entity) and not any(p in excluded_dirs for p in pathlib.Path(lk).parents):
+            if (not any(p in excluded_dirs 
+                        for p in pathlib.PurePosixPath(lk).parents)
+                    and f(lk, entity)):
                 p.set(lk, entity)
 
         return p

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -977,14 +977,19 @@ class Package(object):
         Returns: list
             A list of truthy (logical key, entry) tuples.
         """
+        p = Package()
+
+        excluded_dirs = set()
         if include_directories:
             for lk, _ in self._walk_dir_meta():
-                if f(lk, self[lk.rstrip("/")]):
-                    yield (lk, self[lk.rstrip("/")])
+                if not f(lk, self[lk.rstrip("/")]):
+                    excluded_dirs = excluded_dirs.union({lk})
 
         for lk, entity in self.walk():
-            if f(lk, entity):
-                yield (lk, entity)
+            if f(lk, entity) and not any(p in excluded_dirs for p in pathlib.Path(lk).parents):
+                p.set(lk, entity)
+
+        return p
 
     def reduce(self, f, default=None, include_directories=False):
         """

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -881,7 +881,7 @@ def test_filter():
 
     p_copy = pkg.filter(lambda lk, entry: lk == 'a/' or lk == 'a/df',
                         include_directories=True)
-    assert list(p_copy) == []
+    assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
 
 
 def test_reduce():

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -863,19 +863,25 @@ def test_map():
 
 def test_filter():
     pkg = Package()
-    pkg.set('as/df', LOCAL_MANIFEST)
-    pkg.set('as/qw', LOCAL_MANIFEST)
-    assert list(pkg.filter(lambda lk, entry: lk == 'as/df')) == [
-        ('as/df', pkg['as/df'])
-    ]
+    pkg.set('a/df', LOCAL_MANIFEST)
+    pkg.set('a/qw', LOCAL_MANIFEST)
 
-    pkg['as'].set_meta({'foo': 'bar'})
-    assert list(pkg.filter(lambda lk, entry: lk == 'as/df')) == [
-        ('as/df', pkg['as/df'])
-    ]
-    assert list(pkg.filter(lambda lk, entry: lk == 'as/', include_directories=True)) == [
-        ('as/', pkg['as'])
-    ]
+    p_copy = pkg.filter(lambda lk, entry: lk == 'a/df')
+    assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
+
+    pkg = Package()
+    pkg.set('a/df', LOCAL_MANIFEST)
+    pkg.set('a/qw', LOCAL_MANIFEST)
+    pkg.set('b/df', LOCAL_MANIFEST)
+    pkg['a'].set_meta({'foo': 'bar'})
+    pkg['b'].set_meta({'foo': 'bar'})
+
+    p_copy = pkg.filter(lambda lk, entry: lk == 'a/', include_directories=True)
+    assert list(p_copy) == []
+
+    p_copy = pkg.filter(lambda lk, entry: lk == 'a/' or lk == 'a/df',
+                        include_directories=True)
+    assert list(p_copy) == []
 
 
 def test_reduce():


### PR DESCRIPTION
This PR tweaks the `t4.Package.filter` method to return a filtered copy of a package instead of a list of tuples. This makes more sense for the use case that `filter` was intended for (selecting just parts of packages).