### PR TITLE
Catalog: search hotfix

### DIFF
--- a/catalog/app/containers/NavBar/BucketSelect.js
+++ b/catalog/app/containers/NavBar/BucketSelect.js
@@ -173,7 +173,7 @@ export default RT.composeComponent('NavBar.BucketSelect',
   }),
   ({ autoFocus = false, cancel }) => (
     <Wait.Placeholder fallback={() => <Placeholder />}>
-      <BucketConfig.WithBucketConfigs>
+      <BucketConfig.WithBucketConfigs suggestedOnly>
         {Wait.wait((buckets) => (
           <State buckets={buckets} cancel={cancel}>
             {(state) => (

--- a/catalog/app/utils/BucketConfig.js
+++ b/catalog/app/utils/BucketConfig.js
@@ -14,13 +14,17 @@ export const WithBucketConfigs = RT.composeComponent(
   'BucketConfig.WithBucketConfigs',
   RC.setPropTypes({
     children: PT.func.isRequired,
+    suggestedOnly: PT.bool,
   }),
-  ({ children }) => (
+  ({ children, suggestedOnly = false }) => (
     <Config.Inject>
       {AsyncResult.case({
-        Ok: ({ suggestedBuckets, federations }) =>
-          children(AsyncResult.Ok(federations.filter(({ name }) =>
-            suggestedBuckets.includes(name)))),
+        Ok: ({ suggestedBuckets, federations }) => {
+          const filtered = suggestedOnly
+            ? federations.filter(({ name }) => suggestedBuckets.includes(name))
+            : federations;
+          return children(AsyncResult.Ok(filtered));
+        },
         _: children,
       })}
     </Config.Inject>


### PR DESCRIPTION
Catalog displayed "search not available" when the bucket config is present, but bucket name not included in `suggestedBuckets`.