### PR TITLE
Catalog: display summary in package tree

### DIFF
--- a/catalog/app/containers/Bucket/Overview.js
+++ b/catalog/app/containers/Bucket/Overview.js
@@ -1,32 +1,60 @@
 import * as React from 'react';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { withStyles } from '@material-ui/core/styles';
 
+import * as AWS from 'utils/AWS';
+import AsyncResult from 'utils/AsyncResult';
+import Data from 'utils/Data';
 import * as NamedRoutes from 'utils/NamedRoutes';
 import Link from 'utils/StyledLink';
 import * as RT from 'utils/reactTools';
 
 import Message from './Message';
 import Summary from './Summary';
+import { displayError } from './errors';
+import * as requests from './requests';
 
 
 const EXAMPLE_BUCKET = 'quilt-example';
 
+const whenEmpty = (bucket) => () => (
+  <NamedRoutes.Inject>
+    {({ urls }) => (
+      <Message headline="Getting Started">
+        Welcome to the Quilt T4 catalog for the <strong>{bucket}</strong> bucket.
+        <br />
+        For help getting started with T4 check
+        out <Link to={urls.bucketRoot(EXAMPLE_BUCKET)}>the demo bucket</Link>.
+        <br />
+        To overwrite this landing page with your own, create a
+        new <strong>README.md</strong> at the top level of this bucket.
+      </Message>
+    )}
+  </NamedRoutes.Inject>
+);
+
 export default RT.composeComponent('Bucket.Overview',
-  NamedRoutes.inject(),
-  ({ urls, match: { params: { bucket } } }) => (
-    <Summary
-      bucket={bucket}
-      path=""
-      progress
-      whenEmpty={() => (
-        <Message headline="Getting Started">
-          Welcome to the Quilt T4 catalog for the <strong>{bucket}</strong> bucket.
-          <br />
-          For help getting started with T4 check
-          out <Link to={urls.bucketRoot(EXAMPLE_BUCKET)}>the demo bucket</Link>.
-          <br />
-          To overwrite this landing page with your own, create a
-          new <strong>README.md</strong> at the top level of this bucket.
-        </Message>
+  withStyles(({ spacing: { unit } }) => ({
+    progress: {
+      marginTop: 2 * unit,
+    },
+  })),
+  ({ classes, match: { params: { bucket } } }) => (
+    <AWS.S3.Inject>
+      {(s3) => (
+        <Data
+          fetch={requests.bucketListing}
+          params={{ s3, bucket }}
+        >
+          {AsyncResult.case({
+            // eslint-disable-next-line react/prop-types
+            Ok: ({ files }) => (
+              <Summary files={files} whenEmpty={whenEmpty(bucket)} />
+            ),
+            Err: displayError(),
+            _: () => <CircularProgress className={classes.progress} />,
+          })}
+        </Data>
       )}
-    />
+    </AWS.S3.Inject>
   ));

--- a/catalog/app/containers/Bucket/Summary.js
+++ b/catalog/app/containers/Bucket/Summary.js
@@ -12,22 +12,34 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
 import ContentWindow from 'components/ContentWindow';
-import { S3, Signer } from 'utils/AWS';
+import * as AWS from 'utils/AWS';
 import AsyncResult from 'utils/AsyncResult';
-import { withData } from 'utils/Data';
+import Data from 'utils/Data';
 import * as NamedRoutes from 'utils/NamedRoutes';
 import StyledLink from 'utils/StyledLink';
 import { composeComponent } from 'utils/reactTools';
 import {
+  getBasename,
   getPrefix,
   withoutPrefix,
 } from 'utils/s3paths';
 
-import { displayError } from './errors';
 import * as requests from './requests';
 
 
+const README_RE = /^readme\.md$/i;
+const SUMMARIZE_RE = /^quilt_summarize\.json$/i;
+const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif'];
 const MAX_THUMBNAILS = 100;
+
+const findFile = (re) => R.find(({ key }) => re.test(getBasename(key)));
+
+const extractSummary = R.applySpec({
+  readme: findFile(README_RE),
+  summarize: findFile(SUMMARIZE_RE),
+  images: R.filter(({ key }) =>
+    IMAGE_EXTS.some((ext) => key.endsWith(ext))),
+});
 
 const SummaryItem = composeComponent('Bucket.Summary.Item',
   RC.setPropTypes({
@@ -70,11 +82,9 @@ const Thumbnails = composeComponent('Bucket.Summary.Thumbnails',
   RC.setPropTypes({
     images: PT.array.isRequired,
   }),
-  Signer.inject(),
   RC.withProps(({ images }) => ({
     showing: images.slice(0, MAX_THUMBNAILS),
   })),
-  NamedRoutes.inject(),
   withStyles(({ spacing: { unit } }) => ({
     container: {
       display: 'flex',
@@ -100,98 +110,84 @@ const Thumbnails = composeComponent('Bucket.Summary.Thumbnails',
       },
     },
   })),
-  ({ classes, images, showing, signer, urls }) => (
+  ({ classes, images, showing }) => (
     <SummaryItem
       title={`Images (showing ${showing.length} out of ${images.length})`}
     >
-      <div className={classes.container}>
-        {showing.map((i) => (
-          <Link
-            key={i.key}
-            to={urls.bucketFile(i.bucket, i.key)}
-            className={classes.link}
-          >
-            <img
-              className={classes.img}
-              alt={basename(i.key)}
-              title={basename(i.key)}
-              src={signer.getSignedS3URL(i)}
-            />
-          </Link>
-        ))}
-        {R.times(
-          (i) => <div className={classes.filler} key={`__filler${i}`} />,
-          (5 - (showing.length % 5)) % 5
+      <NamedRoutes.Inject>
+        {({ urls }) => (
+          <AWS.Signer.Inject>
+            {(signer) => (
+              <div className={classes.container}>
+                {showing.map((i) => (
+                  <Link
+                    key={i.key}
+                    to={urls.bucketFile(i.bucket, i.key)}
+                    className={classes.link}
+                  >
+                    <img
+                      className={classes.img}
+                      alt={basename(i.key)}
+                      title={basename(i.key)}
+                      src={signer.getSignedS3URL(i)}
+                    />
+                  </Link>
+                ))}
+                {R.times(
+                  (i) => <div className={classes.filler} key={`__filler${i}`} />,
+                  (5 - (showing.length % 5)) % 5
+                )}
+              </div>
+            )}
+          </AWS.Signer.Inject>
         )}
-      </div>
+      </NamedRoutes.Inject>
     </SummaryItem>
   ));
 
-const Summarize = composeComponent('Bucket.Summary.Summarize',
-  RC.setPropTypes({
-    /**
-     * summarize file handle
-     *
-     * @type {S3Handle}
-     */
-    handle: PT.object.isRequired,
-  }),
-  S3.inject(),
-  withData({
-    params: R.pick(['s3', 'handle']),
-    fetch: requests.summarize,
-  }),
-  ({ data: { result }, children }) => children(result));
-
 export default composeComponent('Bucket.Summary',
   RC.setPropTypes({
-    bucket: PT.string.isRequired,
-    path: PT.string.isRequired,
-    progress: PT.bool,
+    // Array of handles
+    files: PT.array.isRequired,
     whenEmpty: PT.func,
-    showError: PT.bool,
   }),
-  S3.inject(),
-  withData({
-    params: R.pick(['s3', 'bucket', 'path']),
-    fetch: requests.fetchSummary,
-  }),
-  ({
-    data: { result },
-    progress = false,
-    whenEmpty = () => null,
-    showError = true,
-  }) =>
-    AsyncResult.case({
-      _: () => (progress && <CircularProgress />),
-      Err: showError ? displayError() : () => null,
-      // eslint-disable-next-line react/prop-types
-      Ok: ({ readme, images, summarize }) => (
-        <React.Fragment>
-          {!readme && !summarize && !images.length && whenEmpty()}
-          {readme && (
-            <SummaryItemFile
-              title={basename(readme.key)}
-              handle={readme}
-            />
-          )}
-          {!!images.length && <Thumbnails images={images} />}
-          {summarize && (
-            <Summarize handle={summarize}>
-              {AsyncResult.case({
-                Err: () => null,
-                _: () => (progress && <CircularProgress />),
-                Ok: R.map((i) => (
-                  <SummaryItemFile
-                    key={i.key}
-                    // TODO: make a reusable function to compute relative s3 paths or smth
-                    title={withoutPrefix(getPrefix(summarize.key), i.key)}
-                    handle={i}
-                  />
-                )),
-              })}
-            </Summarize>
-          )}
-        </React.Fragment>
-      ),
-    }, result));
+  withStyles(({ spacing: { unit } }) => ({
+    progress: {
+      marginTop: 2 * unit,
+    },
+  })),
+  ({ classes, files, whenEmpty = () => null }) => {
+    const { readme, images, summarize } = extractSummary(files);
+    return (
+      <React.Fragment>
+        {!readme && !summarize && !images.length && whenEmpty()}
+        {readme && (
+          <SummaryItemFile
+            title={basename(readme.key)}
+            handle={readme}
+          />
+        )}
+        {!!images.length && <Thumbnails images={images} />}
+        {summarize && (
+          <AWS.S3.Inject>
+            {(s3) => (
+              <Data fetch={requests.summarize} params={{ s3, handle: summarize }}>
+                {AsyncResult.case({
+                  Err: () => null,
+                  _: () => <CircularProgress className={classes.progress} />,
+                  Ok: R.map((i) => (
+                    <SummaryItemFile
+                      key={i.key}
+                      // TODO: make a reusable function to compute relative s3 paths or smth
+                      title={withoutPrefix(getPrefix(summarize.key), i.key)}
+                      handle={i}
+                    />
+                  )),
+                })}
+              </Data>
+            )}
+          </AWS.S3.Inject>
+        )}
+      </React.Fragment>
+    );
+  });

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -1,17 +1,8 @@
-import { basename } from 'path';
-
 import * as R from 'ramda';
 
-import {
-  ensureNoSlash,
-  getBasename,
-  resolveKey,
-  withoutPrefix,
-  up,
-} from 'utils/s3paths';
+import { resolveKey } from 'utils/s3paths';
 import * as Resource from 'utils/Resource';
 
-import { ListingItem } from './Listing';
 import * as errors from './errors';
 
 
@@ -27,7 +18,7 @@ const catchErrors = (pairs = []) => R.cond([
 ]);
 
 
-export const bucketListing = ({ s3, urls, bucket, path }) =>
+export const bucketListing = ({ s3, bucket, path = '' }) =>
   s3
     .listObjectsV2({
       Bucket: bucket,
@@ -35,47 +26,29 @@ export const bucketListing = ({ s3, urls, bucket, path }) =>
       Prefix: path,
     })
     .promise()
-    .then(R.pipe(
-      R.applySpec({
-        directories: R.pipe(
-          R.prop('CommonPrefixes'),
-          R.pluck('Prefix'),
-          R.filter((d) => d !== '/' && d !== '../'),
-          R.uniq,
-          R.map((name) =>
-            ListingItem.Dir({
-              name: ensureNoSlash(withoutPrefix(path, name)),
-              to: urls.bucketDir(bucket, name),
-            })),
-        ),
-        files: R.pipe(
-          R.prop('Contents'),
-          // filter-out "directory-files" (files that match prefixes)
-          R.filter(({ Key }) => Key !== path && !Key.endsWith('/')),
-          R.map(({ Key, Size, LastModified }) =>
-            ListingItem.File({
-              name: basename(Key),
-              to: urls.bucketFile(bucket, Key),
-              size: Size,
-              modified: LastModified,
-            })),
-        ),
-      }),
-      ({ files, directories }) => [
-        ...(
-          path !== ''
-            ? [ListingItem.Dir({
-              name: '..',
-              to: urls.bucketDir(bucket, up(path)),
-            })]
-            : []
-        ),
-        ...directories,
-        ...files,
-      ],
-      // filter-out files with same name as one of dirs
-      R.uniqBy(ListingItem.case({ Dir: R.prop('name'), File: R.prop('name') })),
-    ))
+    .then(R.applySpec({
+      dirs: R.pipe(
+        R.prop('CommonPrefixes'),
+        R.pluck('Prefix'),
+        R.filter((d) => d !== '/' && d !== '../'),
+        R.uniq,
+      ),
+      files: R.pipe(
+        R.prop('Contents'),
+        // filter-out "directory-files" (files that match prefixes)
+        R.filter(({ Key }) => Key !== path && !Key.endsWith('/')),
+        R.map((i) => ({
+          // TODO: expose VersionId?
+          bucket,
+          key: i.Key,
+          modified: i.LastModified,
+          size: i.Size,
+          etag: i.ETag,
+        })),
+      ),
+      bucket: () => bucket,
+      path: () => path,
+    }))
     .catch(catchErrors());
 
 export const objectVersions = ({ s3, bucket, path }) =>
@@ -91,42 +64,6 @@ export const objectVersions = ({ s3, bucket, path }) =>
         id: v.VersionId,
       })),
     ));
-
-const mkHandle = (bucket) => (i) => ({
-  bucket,
-  key: i.Key,
-  modified: i.LastModified,
-  size: i.Size,
-  etag: i.ETag,
-});
-
-const findFile = (re) => R.find(({ key }) => re.test(getBasename(key)));
-
-const README_RE = /^readme\.md$/i;
-const SUMMARIZE_RE = /^quilt_summarize\.json$/i;
-const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif'];
-
-export const fetchSummary = ({ s3, bucket, path }) =>
-  s3
-    .listObjectsV2({
-      Bucket: bucket,
-      Delimiter: '/',
-      Prefix: path,
-    })
-    .promise()
-    .then(R.pipe(
-      R.prop('Contents'),
-      R.map(mkHandle(bucket)),
-      // filter-out "directory-files" (files that match prefixes)
-      R.filter((f) => f.key !== path && !f.key.endsWith('/')),
-      R.applySpec({
-        readme: findFile(README_RE),
-        summarize: findFile(SUMMARIZE_RE),
-        images: R.filter(({ key }) =>
-          IMAGE_EXTS.some((ext) => key.endsWith(ext))),
-      }),
-    ))
-    .catch(catchErrors());
 
 const isValidManifest = R.both(Array.isArray, R.all(R.is(String)));
 

--- a/catalog/app/utils/s3paths.js
+++ b/catalog/app/utils/s3paths.js
@@ -1,4 +1,5 @@
 import { dirname, basename, resolve } from 'path';
+import { parse as parseUrl } from 'url';
 
 
 /**
@@ -9,6 +10,7 @@ import { dirname, basename, resolve } from 'path';
  * @property {string} region
  * @property {string} bucket
  * @property {string} key
+ * @property {string} version
  * @property {Date} modified
  * @property {number} size
  * @property {string} etag
@@ -127,9 +129,12 @@ export const isS3Url = (url) => url.startsWith('s3://');
  * @returns {S3Handle}
  */
 export const parseS3Url = (url) => {
-  const m = url.match(/^s3:\/\/([a-z0-9-]+)\/(.+)$/);
-  if (!m) throw new Error(`could not parse s3 url '${url}'`);
-  return { bucket: m[1], key: m[2] };
+  const u = parseUrl(url, true);
+  return {
+    bucket: u.hostname,
+    key: (u.pathname || '/').substring(1),
+    version: u.query.versionId,
+  };
 };
 
 /**


### PR DESCRIPTION
Display summary in package tree similar to regular bucket tree.

Limitations:

* objects linked in `quilt_summarize.json` are previewed and linked without version (not using the version from the package revision currently browsed, but the latest one from the bucket)
* object title links to that object's physical location (in bucket tree, not in package tree)
* thumbnails link to images' physical locations (in bucket tree, not in package tree)

Should be merged after #232 and #233 