### PR TITLE
Bucket/requests: objectVersions: filter object by key

### DIFF
--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -83,6 +83,7 @@ export const objectVersions = ({ s3, bucket, path }) =>
     .promise()
     .then(R.pipe(
       R.prop('Versions'),
+      R.filter((v) => v.Key === path),
       R.map((v) => ({
         isLatest: v.IsLatest || false,
         lastModified: v.LastModified,


### PR DESCRIPTION
Version list returned by S3 is only filtered by prefix, not key, so we need to filter it by key manually to drop irrelevant versions