### PR TITLE
Bugfix: return self at end of set_meta call

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -614,6 +614,7 @@ class Package(object):
         Sets user metadata on this Package.
         """
         self._meta['user_meta'] = meta
+        return self
 
     def _fix_sha256(self):
         entries = [entry for key, entry in self.walk() if entry.hash is None]


### PR DESCRIPTION
Corrects an extremely minor bug: the fact that `set_meta` doesn't return the package after being called (unlike every other setter in the API).