### PR TITLE
Update registry defaulting behavior

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -870,9 +870,21 @@ class Package(object):
             dest = registry
 
         # if dest is specified and registry is not use dest as the registry
-        if dest is not None and registry is None:
-            parsed = urlparse(bucket_uri)
-            registry, _, _ = parse_s3_url(parsed)
+        elif dest is not None and registry is None:
+            parsed = urlparse(fix_url(dest))
+
+            # TODO: this should be a helper method?
+            if parsed.scheme == 's3':
+                bucket, _, _ = parse_s3_url(parsed)
+                registry = 's3://' + bucket
+            elif parsed.scheme == 'file':
+                registry = parsed.path
+            else:
+                raise NotImplementedError
+
+        # specifying registry but not dest doesn't make sense
+        elif dest is None and registry is not None:
+            raise NotImplementedError
 
         # if both dest and registry are specified no further work is needed
 

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -840,7 +840,7 @@ class Package(object):
 
         return top_hash.hexdigest()
 
-    def push(self, name, dest, registry=None, message=None):
+    def push(self, name, dest=None, registry=None, message=None):
         """
         Copies objects to path, then creates a new package that points to those objects.
         Copies each object in this package to path according to logical key structure,
@@ -859,12 +859,22 @@ class Package(object):
         validate_package_name(name)
         self._set_commit_message(message)
 
-        if registry is None:
+        # if only a package name is set, set registry and dest to the default registry
+        if dest is None and registry is None:
             registry = get_remote_registry()
             if not registry:
                 raise QuiltException("No registry specified and no default remote "
                                      "registry configured. Please specify a registry "
                                      "or configure a default remote registry with t4.config")
+
+            dest = registry
+
+        # if dest is specified and registry is not use dest as the registry
+        if dest is not None and registry is None:
+            parsed = urlparse(bucket_uri)
+            registry, _, _ = parse_s3_url(parsed)
+
+        # if both dest and registry are specified no further work is needed
 
         self._fix_sha256()
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -111,12 +111,13 @@ def test_default_registry(tmpdir):
             pkg = Package.load(fd)
             assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
 
+    # TODO: fix this test?
     with patch('t4.packages.get_remote_registry') as mock_config:
         mock_config.return_value = new_base_path
         new_pkg.push("Quilt/Test", Path(tmpdir, 'test_dest').resolve().as_uri())
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert pkg['bar'].physical_keys[0].endswith('test_dest/Quilt/Test/bar')
+            assert pkg['bar'].physical_keys[0].endswith('test_default_registry0/bar')
 
 def test_read_manifest(tmpdir):
     """ Verify reading serialized manifest from disk. """
@@ -260,6 +261,7 @@ def test_load_into_t4(tmpdir):
 
         # Manifest copied
         top_hash = new_pkg.top_hash()
+        # FIXME: understand what is happening with these byte calls
         bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
         bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -261,7 +261,6 @@ def test_load_into_t4(tmpdir):
 
         # Manifest copied
         top_hash = new_pkg.top_hash()
-        # FIXME: understand what is happening with these byte calls
         bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
         bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -111,13 +111,12 @@ def test_default_registry(tmpdir):
             pkg = Package.load(fd)
             assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
 
-    # TODO: fix this test?
     with patch('t4.packages.get_remote_registry') as mock_config:
         mock_config.return_value = new_base_path
-        new_pkg.push("Quilt/Test", Path(tmpdir, 'test_dest').resolve().as_uri())
+        new_pkg.push("Quilt/Test")
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert pkg['bar'].physical_keys[0].endswith('test_default_registry0/bar')
+            assert pkg['bar'].physical_keys[0].endswith('.quilttest/Quilt/Test/bar')
 
 def test_read_manifest(tmpdir):
     """ Verify reading serialized manifest from disk. """


### PR DESCRIPTION
A recent PR added a concept of a default registry to user configuration, allowing users to under-specify the parameters in `push` and use the API in a more convenient way.

This PR tweaks how `push` interacts with the default remote registry, using it to parameterize the `dest` kwarg instead of the `registry` kwarg. This is how I expected the API to work, and it makes more sense to me.

Old behavior:

```python
# assume that the default registry is 's3://my-bucket'
p = t4.Package()

# == p.push('foo/bar', dest='s3://other-bucket/foo/bar', registry='s3://my-bucket/')
p.push("foo/bar", "s3://other-bucket")
```

This is confusing because it looks like I'm pushing `foo/bar` to the `other-bucket` S3 bucket. However, instead I am pushing the _files_ to `s3://other-bucket`, and the _package manifest_ to `s3://my-bucket`. From my perspective as an end user when I go to visit `s3://other-bucket` it looks like my package disappeared!

New behavior:

```python
# assume that the default registry is 's3://my-bucket'
p = t4.Package()

# == p.push('foo/bar', dest='s3://my-bucket/foo/bar', registry='s3://my-bucket/')
p.push("foo/bar")   

# == p.push('foo/bar', dest='s3://other-bucket/foo/bar', registry='s3://other-bucket/')
p.push("foo/bar", dest="s3://other-bucket/foo/bar")

# raises; 'dest' is still a required argument
p.push("foo/bar", registry="s3://my-bucket/")
```

Changes:
* The default registry is now only used if only the package name is specified (e.g. `p.push('foo/bar')`).
* `registry` is inferred from `dest`. If the target is `s3://` the root of the bucket is passed as the registry, if the target is `file:///` the path is used as the registry.

If you want to deposit the files in one bucket and the manifest in another you can still do that with a fully specified `push`.