### PR TITLE
Make registry argument to install optional

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -331,6 +331,8 @@ class Package(object):
                 raise QuiltException("No registry specified and no default remote "
                                      "registry configured. Please specify a registry "
                                      "or configure a default remote registry with t4.config")
+        elif registry == 'local':
+            registry = get_local_registry()
         
         if dest_registry is None:
             dest_registry = get_local_registry()

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -317,7 +317,8 @@ class Package(object):
 
         Args:
             name(str): Name of package to install.
-            registry(str): Registry where package is located.
+            registry(str): Registry where package is located. 
+                Defaults to the default remote registry.
             pkg_hash(str): Hash of package to install. Defaults to latest.
             dest(str): Local path to download files to.
             dest_registry(str): Registry to install package to. Defaults to local registry.

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -311,7 +311,7 @@ class Package(object):
         return _create_str(results_dict)
 
     @classmethod
-    def install(cls, name, registry, pkg_hash=None, dest=None, dest_registry=None):
+    def install(cls, name, registry=None, pkg_hash=None, dest=None, dest_registry=None):
         """
         Installs a named package to the local registry and downloads its files.
 
@@ -325,6 +325,13 @@ class Package(object):
         Returns:
             A new Package that points to files on your local machine.
         """
+        if registry is None:
+            registry = get_remote_registry()
+            if not registry:
+                raise QuiltException("No registry specified and no default remote "
+                                     "registry configured. Please specify a registry "
+                                     "or configure a default remote registry with t4.config")
+        
         if dest_registry is None:
             dest_registry = get_local_registry()
 
@@ -339,7 +346,6 @@ class Package(object):
         """
         Load a package into memory from a registry without making a local copy of
         the manifest.
-
         Args:
             name(string): name of package to load
             registry(string): location of registry to load package from

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -200,6 +200,31 @@ def test_browse_package_from_registry():
         assert '{}/.quilt/packages/{}'.format(remote_registry, pkghash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
+def test_local_install(tmpdir):
+    """Verify that installing from a local package works as expected."""
+    with patch('t4.packages.get_local_registry') as get_local_registry_mock, \
+        patch('t4.Package.push') as push_mock:
+        local_registry = tmpdir
+        get_local_registry_mock.return_value = local_registry
+        pkg = Package()
+        pkg.build('Quilt/nice-name')
+
+        t4.Package.install('Quilt/nice-name', registry='local', dest='./')
+        push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=local_registry)
+
+def test_remote_install(tmpdir):
+    """Verify that installing from a local package works as expected."""
+    with patch('t4.packages.get_remote_registry') as get_remote_registry_mock, \
+        patch('t4.packages.get_local_registry') as get_local_registry_mock, \
+        patch('t4.Package.push') as push_mock:
+        remote_registry = tmpdir
+        get_local_registry_mock.return_value = get_remote_registry_mock.return_value = remote_registry
+        pkg = Package()
+        pkg.build('Quilt/nice-name')
+
+        t4.Package.install('Quilt/nice-name', dest='./')
+        push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=remote_registry)
+
 def test_package_fetch(tmpdir):
     """ Package.fetch() on nested, relative keys """
     input_dir = os.path.dirname(__file__)


### PR DESCRIPTION
We now have an understanding of a default remote registry, but `install` still requires an explicit registry. This PR makes the `registry` argument optional; if the argument is omitted the default remote registry will be used, unless no default remote registry is configured, in which case the function will raise an error.