### PR TITLE
Support nested directories in ignore rules

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -560,8 +560,7 @@ class Package(object):
             files = src_path.rglob('*')
             ignore = src_path / '.quiltignore'
             if ignore.exists():
-                ignore_rules = ignore.read_text('utf-8').split("\n")
-                files = quiltignore_filter(files, ignore_rules, 'file')
+                files = quiltignore_filter(files, ignore, 'file')
 
             for f in files:
                 if not f.is_file():

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -295,17 +295,21 @@ def get_local_registry():
 def get_remote_registry():
     return load_config().get('default_remote_registry', None)
 
-def quiltignore_filter(paths, ignore_rules, url_scheme):
-    """Given a list paths, filter out the paths which are captured by the given
-    ignore rules.
+def quiltignore_filter(paths, ignore, url_scheme):
+    """Given a list of paths, filter out the paths which are captured by the 
+    given ignore rules.
 
     Args:
         paths (list): a list or iterable of paths
-        ignore_rules (list): a list or iterable of ignore rules, in Unix shell
+        ignore (path): a path to the file defining ignore rules, in Unix shell
             style wildcard format
         url_scheme (str): the URL scheme, only the "file" scheme is currently
             supported
     """
+    ignore_rules = ignore.read_text('utf-8').split("\n")
+    ignore_rules = ['*/' + rule for rule in ignore_rules if rule]
+    print(ignore_rules)
+
     if url_scheme == 'file':
         from fnmatch import fnmatch
 
@@ -318,7 +322,6 @@ def quiltignore_filter(paths, ignore_rules, url_scheme):
 
         filtered_dirs = dirs.copy()
         for ignore_rule in ignore_rules:
-            ignore_rule = os.getcwd() + '/' + ignore_rule
 
             for pkg_dir in filtered_dirs.copy():
                 # copy git behavior --- git matches paths and directories equivalently.

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -308,7 +308,6 @@ def quiltignore_filter(paths, ignore, url_scheme):
     """
     ignore_rules = ignore.read_text('utf-8').split("\n")
     ignore_rules = ['*/' + rule for rule in ignore_rules if rule]
-    print(ignore_rules)
 
     if url_scheme == 'file':
         from fnmatch import fnmatch


### PR DESCRIPTION
The extant implementation of the `.quiltignore` filter rule only applies ignore rules with respect to the _current_ directory, which was unintentional&mdash;I wanted the filter rules to apply the same way `git` applies them, recursively.

Previous behavior is that a `.git` ignore rule ignores `path/to/root/.git`, but not `path/to/root/subfolder/.git`.

New behavior is that `.git` ignores both `path/to/root/.git` and `path/to/root/subfolder/.git`, as well as any other `path/to/root/[...]/.git`.

This PR also cleans up the code slightly by moving parsing out of `set_dir` and into the `quiltignore_filter` helper function.