### PR TITLE
Provide default install location

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -76,7 +76,7 @@ def get(src):
 
     return FormatRegistry.deserialize(data, meta, ext=ext), meta.get('user_meta')
 
-        
+
 def _tophashes_with_packages(registry=None):
     """Return a dictionary of tophashes and their corresponding packages
 
@@ -365,16 +365,16 @@ def config(*autoconfig_url, **config_values):
 
     To retrieve the current config, call directly, without arguments:
 
-        >>> import t4 as he
-        >>> he.config()
+        >>> import t4
+        >>> t4.config()
 
     To trigger autoconfiguration, call with just the navigator URL:
 
-        >>> he.config('https://example.com')
+        >>> t4.config('https://example.com')
 
     To set config values, call with one or more key=value pairs:
 
-        >>> he.config(navigator_url='http://example.com',
+        >>> t4.config(navigator_url='http://example.com',
         ...           elastic_search_url='http://example.com/queries')
 
     When setting config values, unrecognized values are rejected.  Acceptable

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -54,6 +54,10 @@ default_local_registry: "{}"
 # default target for operations like push and browse
 default_remote_registry:
 
+# default_install_location: <url string, default: null>
+# default filesystem target for the install operation
+default_install_location:
+
 # Quilt2 registry URL
 registry_url: https://pkg.quiltdata.com
 """.format(BASE_PATH.as_uri())
@@ -281,6 +285,12 @@ def validate_package_name(name):
     if not re.match(PACKAGE_NAME_FORMAT, name):
         raise QuiltException("Invalid package name, must contain exactly one /.")
 
+def get_package_registry(path=None):
+    """ Returns the package registry root for a given path """
+    if path is None:
+        path = BASE_PATH.as_uri()
+    return path.rstrip('/') + '/.quilt'
+
 def load_config():
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
@@ -294,6 +304,12 @@ def get_local_registry():
 
 def get_remote_registry():
     return load_config().get('default_remote_registry', None)
+
+def get_install_location():
+    loc = load_config().get('default_install_location')
+    if loc is None:
+        loc = get_package_registry() + '/' + 'data/'
+    return loc
 
 def quiltignore_filter(paths, ignore, url_scheme):
     """Given a list of paths, filter out the paths which are captured by the 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -118,6 +118,18 @@ def test_default_registry(tmpdir):
             pkg = Package.load(fd)
             assert pkg['bar'].physical_keys[0].endswith('.quilttest/Quilt/Test/bar')
 
+@patch('appdirs.user_data_dir', lambda x,y: os.path.join('test_appdir', x))
+@patch('t4.Package.browse', lambda name, registry, pkg_hash: Package())
+def test_default_install_location(tmpdir):
+    """Verify that pushes to the default local install location work as expected"""
+    with patch('t4.Package.push') as push_mock:
+        Package.install('Quilt/nice-name', registry='s3://my-test-bucket')
+        push_mock.assert_called_once_with(
+            dest=t4.util.get_install_location(), 
+            name='Quilt/nice-name',
+            registry=ANY
+        )
+
 def test_read_manifest(tmpdir):
     """ Verify reading serialized manifest from disk. """
     with open(LOCAL_MANIFEST) as fd:

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -15,7 +15,7 @@ class TestAPI():
             'navigator_url': 'https://foo.bar',
             'elastic_search_url': 'https://es.foo',
             'accept_invalid_config_keys': 'yup',
-            }
+        }
         responses.add(responses.GET, 'https://foo.bar/config.json', json=content, status=200)
 
         he.config('foo.bar')
@@ -28,6 +28,7 @@ class TestAPI():
 
         content['default_local_registry'] = util.BASE_PATH.as_uri()
         content['default_remote_registry'] = None
+        content['default_install_location'] = None
         content['registry_url'] = 'https://pkg.quiltdata.com'
 
         assert config == content


### PR DESCRIPTION
Currently `t4.Package.install` must be parameterized with a `dest`, otherwise it doesn't know where to send the data, since we don't provide a default local location.

This PR adds two things:
* A default `install` `dest`. This will be `<appdirs>/.quilt/data/`; a neighbor of `<appdirs>/.quilt/named_packages` and `<appdirs>/.quilt/packages`.
* A new `default_install_location` flag that can be set using `t4.config`. If unset, the default install location described above will be used. If set, the file path this flag is set to will be used instead.