### PR TITLE
Cut new release of pypi to 0.0.8

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.0.7"
+VERSION = "0.0.8"
 
 def readme():
     readme_short = """


### PR DESCRIPTION
Release is live here: https://pypi.org/project/t4/0.0.8/