### PR TITLE
Implement package module import

### DIFF
--- a/api/python/t4/__init__.py
+++ b/api/python/t4/__init__.py
@@ -1,4 +1,3 @@
-
 """T4 API"""
 
 # Suppress numpy warnings

--- a/api/python/t4/__init__.py
+++ b/api/python/t4/__init__.py
@@ -18,3 +18,6 @@ from .api import (
 from .packages import Package
 
 from .bucket import Bucket
+
+from .imports import start_data_package_loader
+start_data_package_loader()

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -72,7 +72,6 @@ class DataPackageFinder:
             return None
         else:
             return ModuleSpec(fullname, DataPackageLoader())
-        return ModuleSpec(fullname, DataPackageFinder()) if 't4' in fullname else None
 
 
 def start_data_package_loader():

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -15,7 +15,7 @@ class DataPackageLoader:
     """
 
     @classmethod
-    def create_module(cls, spec):
+    def create_module(cls, spec):  # pylint: disable=unused-argument
         """
         Module creator. Returning None causes Python to use the default module creator.
         """
@@ -54,6 +54,7 @@ class DataPackageLoader:
             raise NotImplementedError
 
 
+# pylint: disable=too-few-public-methods
 class DataPackageFinder:
     """
     Data package module loader finder. This class sits on `sys.meta_path` and returns the
@@ -61,7 +62,7 @@ class DataPackageFinder:
     """
 
     @classmethod
-    def find_spec(cls, fullname, path=None, target=None):
+    def find_spec(cls, fullname, path=None, target=None):  # pylint: disable=unused-argument
         """
         This functions is what gets executed by the loader.
         """

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -49,6 +49,9 @@ class DataPackageImporter:
             module.__path__ = MODULE_PATH
             return module
 
+        else:
+            assert False
+
 
 # pylint: disable=too-few-public-methods
 class DataPackageFinder:
@@ -66,7 +69,7 @@ class DataPackageFinder:
         # consistency issues. For now let's avoid, but you can see the full code at
         # https://github.com/ResidentMario/package-autorelaod/blob/master/loader.py
         name_parts = fullname.split('.')
-        if name_parts[:2] != ['t4', 'data'] or len(fullname.split('.')) > 3:
+        if name_parts[:2] != ['t4', 'data'] or len(name_parts) > 3:
             return None
         else:
             return ModuleSpec(fullname, DataPackageImporter())

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -1,0 +1,68 @@
+"""Implementation of the Python Quilt T4 data package loader."""
+
+from importlib.machinery import ModuleSpec
+from t4.util import BASE_PATH
+from t4 import list_packages, Package
+
+
+MODULE_PATH = [BASE_PATH / '.quilt']
+
+
+class DataPackageLoader:
+    """
+    Data package module loader. Executes package import code and adds the package to the
+    module cache.
+    """
+
+    @classmethod
+    def create_module(cls, spec):
+        """
+        Module creator. Returning None causes Python to use the default module creator.
+        """
+        return None
+
+    @classmethod
+    def exec_module(cls, module):
+        """
+        Module executor.
+        """
+        name_parts = module.__name__.split('.')
+
+        if module.__name__ == 't4.data':
+            # __path__ must be set even if the package is virtual. Since __path__ will be
+            # scanned by all other finders preceding this one in sys.meta_path order, make sure
+            # it points to someplace lacking importable objects
+            module.__path__ = MODULE_PATH
+            return module
+
+        elif len(name_parts) == 3:  # e.g. module.__name__ == t4.data.foo
+            namespace = name_parts[2]
+
+            # we do not know the name the user will ask for, so populate all valid names
+            for pkg in list_packages():
+                pkg_user, pkg_name = pkg.split('/')
+                if pkg_user == namespace:
+                    module.__dict__.update({pkg_name: Package.browse(pkg)})
+
+            module.__path__ = MODULE_PATH
+            return module
+
+        else:
+            # an implementation for subpackage imports exists, but this has significant
+            # consistency issues. For now let's avoid, but you can see the full code at
+            # https://github.com/ResidentMario/package-autorelaod/blob/master/loader.py
+            raise NotImplementedError
+
+
+class DataPackageFinder:
+    """
+    Data package module loader finder. This class sits on `sys.meta_path` and returns the
+    loader it knows for a given path, if it knows a compatible loader.
+    """
+
+    @classmethod
+    def find_spec(cls, fullname, path=None, target=None):
+        """
+        This functions is what gets executed by the loader.
+        """
+        return ModuleSpec(fullname, DataPackageLoader()) if 't4' in fullname else None

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -1,6 +1,8 @@
 """Implementation of the Python Quilt T4 data package loader."""
 
 from importlib.machinery import ModuleSpec
+import sys
+
 from t4.util import BASE_PATH
 from t4 import list_packages, Package
 
@@ -66,4 +68,16 @@ class DataPackageFinder:
         """
         This functions is what gets executed by the loader.
         """
-        return ModuleSpec(fullname, DataPackageLoader()) if 't4' in fullname else None
+        if 't4' not in fullname:
+            return None
+        else:
+            return ModuleSpec(fullname, DataPackageLoader())
+        return ModuleSpec(fullname, DataPackageFinder()) if 't4' in fullname else None
+
+
+def start_data_package_loader():
+    """
+    Adds the data package loader to the module loaders.
+    """
+    pass
+    sys.meta_path.append(DataPackageFinder())

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -65,7 +65,8 @@ class DataPackageFinder:
         # an implementation for subpackage imports exists, but this has significant
         # consistency issues. For now let's avoid, but you can see the full code at
         # https://github.com/ResidentMario/package-autorelaod/blob/master/loader.py
-        if not fullname.startswith('t4.data') or len(fullname.split('.')) > 3:
+        name_parts = fullname.split('.')
+        if name_parts[:2] != ['t4', 'data'] or len(fullname.split('.')) > 3:
             return None
         else:
             return ModuleSpec(fullname, DataPackageImporter())

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -79,5 +79,4 @@ def start_data_package_loader():
     """
     Adds the data package loader to the module loaders.
     """
-    pass
     sys.meta_path.append(DataPackageFinder())

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -49,12 +49,6 @@ class DataPackageImporter:
             module.__path__ = MODULE_PATH
             return module
 
-        else:
-            # an implementation for subpackage imports exists, but this has significant
-            # consistency issues. For now let's avoid, but you can see the full code at
-            # https://github.com/ResidentMario/package-autorelaod/blob/master/loader.py
-            raise NotImplementedError
-
 
 # pylint: disable=too-few-public-methods
 class DataPackageFinder:
@@ -68,7 +62,10 @@ class DataPackageFinder:
         """
         This functions is what gets executed by the loader.
         """
-        if not fullname.startswith('t4.data'):
+        # an implementation for subpackage imports exists, but this has significant
+        # consistency issues. For now let's avoid, but you can see the full code at
+        # https://github.com/ResidentMario/package-autorelaod/blob/master/loader.py
+        if not fullname.startswith('t4.data') or len(fullname.split('.')) > 3:
             return None
         else:
             return ModuleSpec(fullname, DataPackageImporter())

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -7,7 +7,7 @@ from t4.util import BASE_PATH
 from t4 import list_packages, Package
 
 
-MODULE_PATH = [BASE_PATH / '.quilt']
+MODULE_PATH = []
 
 
 class DataPackageImporter:

--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -10,7 +10,7 @@ from t4 import list_packages, Package
 MODULE_PATH = [BASE_PATH / '.quilt']
 
 
-class DataPackageLoader:
+class DataPackageImporter:
     """
     Data package module loader. Executes package import code and adds the package to the
     module cache.
@@ -44,7 +44,7 @@ class DataPackageLoader:
             for pkg in list_packages():
                 pkg_user, pkg_name = pkg.split('/')
                 if pkg_user == namespace:
-                    module.__dict__.update({pkg_name: Package.browse(pkg)})
+                    module.__dict__[pkg_name] = Package.browse(pkg)
 
             module.__path__ = MODULE_PATH
             return module
@@ -68,10 +68,10 @@ class DataPackageFinder:
         """
         This functions is what gets executed by the loader.
         """
-        if 't4' not in fullname:
+        if not fullname.startswith('t4.data'):
             return None
         else:
-            return ModuleSpec(fullname, DataPackageLoader())
+            return ModuleSpec(fullname, DataPackageImporter())
 
 
 def start_data_package_loader():

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -940,3 +940,17 @@ def test_reduce():
         ('as/df', pkg['as/df']),
         ('as/qw', pkg['as/qw'])
     ]
+
+
+def test_import():
+    with patch('t4.Package.browse') as browse_mock, \
+        patch('t4.imports.list_packages') as list_packages_mock:
+        browse_mock.return_value = t4.Package()
+        list_packages_mock.return_value = ['foo/bar', 'foo/baz']
+
+        from t4.data.foo import bar
+        assert isinstance(bar, Package)
+        browse_mock.assert_has_calls([call('foo/baz'), call('foo/bar')], any_order=True)
+
+        from t4.data import foo
+        assert hasattr(foo, 'bar') and hasattr(foo, 'baz')


### PR DESCRIPTION
This PR adds the ability to import a package as a module directly inside of a Python file.

Quilt 2 serves as prior art for this. This PR uses a slightly cleaned-up Python 3.6 way of doing things.