### PR TITLE
Improve Package repr

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -255,7 +255,7 @@ class Package(object):
                 self_repr += key + '\n'
                 i += 1
 
-        def _create_str(results_dict, level=0, indent='─', parent=True):
+        def _create_str(results_dict, level=0, parent=True):
             """
             Creates a string from the results dict
             """

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -234,29 +234,12 @@ class Package(object):
         self._children = {}
         self._meta = {'version': 'v0'}
 
-    def _unlimited_repr(self, level=0, indent='  '):
-        """
-        String representation without line limit.
-        """
-        self_repr = ''
-        for child_key in sorted(self.keys()):
-            if isinstance(self[child_key], Package):
-                child_entry = indent*level + child_key + '/\n'
-                self_repr += child_entry
-                self_repr += self[child_key].__repr__(level+1, indent)
-            else: # leaf node
-                self_repr += indent*level + child_key + '\n'
-        return self_repr
-
     def __repr__(self, max_lines=20):
         """
         String representation of the Package.
         """
         if not self.keys():
-            return "(empty Package)"
-
-        if max_lines is None:
-            return self._unlimited_repr()
+            return '(empty Package)'
 
         if len(self.keys()) > max_lines:
             # If there aren't enough lines to display all top-level children,
@@ -271,16 +254,31 @@ class Package(object):
                     key = key + '/'
                 self_repr += key + '\n'
                 i += 1
-            assert False, "This should never happen"
 
-        def _create_str(results_dict, level=0, indent='  '):
+        def _create_str(results_dict, level=0, indent='─', parent=True):
             """
             Creates a string from the results dict
             """
             result = ''
-            for key in sorted(results_dict.keys()):
-                result += indent*level + key + '\n'
-                result += _create_str(results_dict[key], level+1, indent)
+            keys = sorted(results_dict.keys())
+            if not keys:
+                return result
+
+            if parent:
+                has_remote_entries = any(
+                    self.map(
+                        lambda lk, entry: urlparse(
+                            fix_url(_to_singleton(entry.physical_keys))
+                        ).scheme != 'file'
+                    )
+                )
+                pkg_type = 'remote' if has_remote_entries else 'local'
+                result = f'({pkg_type} Package)\n'
+
+            for key in keys:
+                result += ' ' + ('  ' * level) + '└─' + key + '\n'
+                result += _create_str(results_dict[key], level + 1, indent, parent=False)
+
             return result
 
         # candidates is a deque of 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -833,18 +833,19 @@ def test_siblings_succeed():
     pkg.set('as/df', LOCAL_MANIFEST)
     pkg.set('as/qw', LOCAL_MANIFEST)
 
-def test_repr():
+def test_local_repr():
     TEST_REPR = (
-        "asdf\n"
-        "path1/\n"
-        "  asdf\n"
-        "  qwer\n"
-        "path2/\n"
-        "  first/\n"
-        "    asdf\n"
-        "  second/\n"
-        "    asdf\n"
-        "qwer\n"
+        "(local Package)\n"
+        " └─asdf\n"
+        " └─path1/\n"
+        "   └─asdf\n"
+        "   └─qwer\n"
+        " └─path2/\n"
+        "   └─first/\n"
+        "     └─asdf\n"
+        "   └─second/\n"
+        "     └─asdf\n"
+        " └─qwer\n"
     )
     pkg = Package()
     pkg.set('asdf', LOCAL_MANIFEST)
@@ -855,21 +856,25 @@ def test_repr():
     pkg.set('path2/second/asdf', LOCAL_MANIFEST)
     assert repr(pkg) == TEST_REPR
 
-def test_long_repr():
-    pkg = Package()
-    for i in range(30):
-        pkg.set('path{}/asdf'.format(i), LOCAL_MANIFEST)
-    r = repr(pkg)
-    assert r.count('\n') == 20
-    assert r[-4:] == '...\n'
+def test_remote_repr(tmpdir):
+    with patch('t4.packages.get_size_and_meta', return_value=(0, dict(), '0')):
+        TEST_REPR = (
+            "(remote Package)\n"
+            " └─asdf\n"
+        )
+        pkg = Package()
+        pkg.set('asdf', 's3://my-bucket/asdf')
+        assert repr(pkg) == TEST_REPR
 
-    pkg = Package()
-    for i in range(10):
-        pkg.set('path{}/asdf'.format(i), LOCAL_MANIFEST)
-        pkg.set('path{}/qwer'.format(i), LOCAL_MANIFEST)
-    pkgrepr = repr(pkg)
-    assert pkgrepr.count('\n') == 20
-    assert pkgrepr.find('path9/') > 0
+        TEST_REPR = (
+            "(remote Package)\n"
+            " └─asdf\n"
+            " └─qwer\n"
+        )
+        pkg = Package()
+        pkg.set('asdf', 's3://my-bucket/asdf')
+        pkg.set('qwer', LOCAL_MANIFEST)
+        assert repr(pkg) == TEST_REPR
 
 def test_repr_empty_package():
     pkg = Package()


### PR DESCRIPTION
I've perturbed the behavior of `Package.__repr__`. There are two new behaviors:

* The `__repr__` is headed by a `(local Package)` or `(remote Package)` header, which states whether the package is local (the physical key are all local) or remote (at least one physical key is remote).
* The `__repr__` prefixes package entries with nice `└─` characters.

I also removed an old "unlimited lines repr", which (1) had the old behavior and (2) duplicated the logic in `__repr__`.

Example of the new `__repr__`:

```
(local Package)
 └─api/
   └─python/
     └─.pylintrc
     └─.pytest_cache/
       └─.gitignore
       └─README.md
       └─v/
     └─TESTS_README
     └─pytest.ini
     └─setup.py
     └─setup.txt
     └─t4.egg-info/
     └─t4/
       └─LICENSE
       └─__init__.py
       └─__pycache__/
       └─api.py
       └─bucket.py
     └─tests/
     └─tox.ini
 ...
```