### PR TITLE
Remove Jupyter notebooks from project languages breadcrumb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
This commit adds a one-line `.gitattributes` file that [overrides which files are detectable by `linguist`](https://github.com/github/linguist#detectable), the library that GitHub uses to generate the languages breadcrumb at the top of the project homepage.

Specifically, it removes `*.ipynb` notebooks from the linguist-detectable filetypes. That's because even though we only have a couple of notebooks in the `tests/` directory, they're still large enough to consume most of the space in the project:

<img width="990" alt="screen shot 2019-02-21 at 3 50 30 pm" src="https://user-images.githubusercontent.com/3466341/53209837-a220ea00-35f0-11e9-86ec-76fb75177897.png">

Removing these from the breadcrumb would provide the correct information about this project&mdash;that it's JavaScript+Python.