### PR TITLE
Improved list_packages

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -68,7 +68,7 @@ setup(
         'six>=1.10.0',
         'tqdm>=4.26.0',
         'xattr>=0.9.6; platform_system!="Windows"',
-        'arrow'
+        'humanize'
     ],
     extras_require={
         'tests': [

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -68,6 +68,7 @@ setup(
         'six>=1.10.0',
         'tqdm>=4.26.0',
         'xattr>=0.9.6; platform_system!="Windows"',
+        'arrow'
     ],
     extras_require={
         'tests': [

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -261,7 +261,7 @@ def list_packages(registry=None):
                    f"\n")
             for name, tophash, ctime, size in pkg_info:
                 out += (f"{self._fmt_str(name, pkg_name_display_width)}"
-                        f"{tophash[:12]}   "
+                        f"{self._fmt_str(tophash[:12], 15)}"
                         f"{self._fmt_str(arrow.get(ctime).humanize(), 15)}"
                         f"{self._fmt_str(self._humanize_bytesize(size), 15).rstrip(' ')}\n")
             return out
@@ -304,6 +304,13 @@ def list_packages(registry=None):
             pkg_info += [[pkg_name, hash, ctime, size] for (hash, ctime, size) in
                          zip(pkg_hashes, pkg_ctimes, pkg_sizes)]
 
+        def sorter(pkg_info_tup):
+            pkg_name, pkg_cdate = pkg_info_tup[0], pkg_info_tup[2]
+            is_latest = ':latest' in pkg_name
+            pkg_realname = pkg_name.replace(':latest', '')
+            return (pkg_realname, not is_latest, -pkg_cdate)
+
+        pkg_info = sorted(pkg_info, key=sorter)
         return PackageList(pkg_info)
 
     elif registry_url.scheme == 's3':
@@ -354,7 +361,7 @@ def list_packages(registry=None):
                     )
                     pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
-                pkg_info += [[pkg_name, hash, ctime, size] for (pkg_name, hash, ctime, size) in
+                pkg_info += [(pkg_name, hash, ctime, size) for (pkg_name, hash, ctime, size) in
                              zip(pkg_names, pkg_hashes, pkg_ctimes, pkg_sizes)]
 
         return PackageList(pkg_info)

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -255,10 +255,10 @@ def list_packages(registry=None):
                 tdelta_str = humanize.naturaltime(tdelta)
                 size_str = humanize.naturalsize(pkg_dict['size'])
 
-                out += (f"{self._fmt_str(pkg_dict['pkg_name'], pkg_name_display_width)}"
-                        f"{self._fmt_str(pkg_dict['top_hash'][:12], 15)}"
-                        f"{self._fmt_str(tdelta_str, 15)}"
-                        f"{self._fmt_str(size_str, 15).rstrip(' ')}\n")
+                out += (f"{self._fmt_str(pkg_dict['pkg_name'], pkg_name_display_width)}\t"
+                        f"{self._fmt_str(pkg_dict['top_hash'][:12], 15)}\t"
+                        f"{self._fmt_str(tdelta_str, 15)}\t"
+                        f"{self._fmt_str(size_str, 15).rstrip(' ')}\t\n")
             return out
 
     base_registry = get_package_registry(fix_url(registry) if registry else None)

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -240,7 +240,7 @@ def list_packages(registry=None):
 
             pkg_hashes = []
             pkg_sizes = []
-            pkg_mtimes = []
+            pkg_ctimes = []
             for pkg_hash_path in named_path.rglob('*/'):
                 # TODO: logic for 'latest'            
                 if pkg_hash_path.name == 'latest':
@@ -250,14 +250,14 @@ def list_packages(registry=None):
                     pkg_hash = fp.read()
                     pkg_hashes.append(pkg_hash)
 
-                pkg_mtimes.append(pkg_hash_path.stat().st_ctime)
+                pkg_ctimes.append(pkg_hash_path.stat().st_ctime)
 
                 from t4 import Package
                 pkg = Package.browse(name, pkg_hash=pkg_hash)
                 pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
-            pkg_info += [[name, hash, mtime, size] for (hash, mtime, size) in
-                         zip(pkg_hashes, pkg_mtimes, pkg_sizes)]
+            pkg_info += [[name, hash, ctime, size] for (hash, ctime, size) in
+                         zip(pkg_hashes, pkg_ctimes, pkg_sizes)]
 
         return PackageList(pkg_info)
 

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -232,7 +232,7 @@ def list_packages(registry=None):
         @staticmethod
         def _fmt_str(string, strlen):
             """Formats strings to a certain width"""
-            if len(string) > strlen - 3:
+            if len(string) > strlen - 1:
                 return string[:strlen - 1] + '…'
             else:
                 return string.ljust(strlen)

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -212,12 +212,10 @@ def list_packages(registry=None):
         """Display wrapper for list_packages"""
 
         def __init__(self, pkg_info):
-            self.pkg_names = [info[0] for info in pkg_info]            
+            self.pkg_names = [info[0].replace(':latest', '') for info in pkg_info]
+            self._repr = self.create_str(pkg_info)
 
         def __repr__(self):
-            if not hasattr(self, '_repr'):
-                self._repr = self.create_str(self.pkg_info)
-
             return self._repr
 
         def __iter__(self):
@@ -251,7 +249,11 @@ def list_packages(registry=None):
 
         def create_str(self, pkg_info):
             """Generates a human-readable string representation of a registry."""
-            pkg_name_display_width = max(max([len(info[0]) for info in pkg_info]), 30)
+            if pkg_info:
+                pkg_name_display_width = max(max([len(info[0]) for info in pkg_info]), 30)
+            else:
+                pkg_name_display_width = 30
+
             out = (f"{self._fmt_str('PACKAGE', pkg_name_display_width)}"
                    f"TOPHASH        "
                    f"CREATED        "
@@ -261,7 +263,7 @@ def list_packages(registry=None):
                 out += (f"{self._fmt_str(name, pkg_name_display_width)}"
                         f"{tophash[:12]}   "
                         f"{self._fmt_str(arrow.get(ctime).humanize(), 15)}"
-                        f"{self._fmt_str(self._humanize_bytesize(size), 15)}\n")
+                        f"{self._fmt_str(self._humanize_bytesize(size), 15).rstrip(' ')}\n")
             return out
 
     base_registry = get_package_registry(fix_url(registry) if registry else None)

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -256,14 +256,13 @@ def list_packages(registry=None):
                 size_str = humanize.naturalsize(pkg_dict['size'])
 
                 out += (f"{self._fmt_str(pkg_dict['pkg_name'], pkg_name_display_width)}"
-                        f"{self._fmt_str(pkg_dict['hash'][:12], 15)}"
+                        f"{self._fmt_str(pkg_dict['top_hash'][:12], 15)}"
                         f"{self._fmt_str(tdelta_str, 15)}"
                         f"{self._fmt_str(size_str, 15).rstrip(' ')}\n")
             return out
 
     base_registry = get_package_registry(fix_url(registry) if registry else None)
     named_packages = base_registry + '/named_packages'
-    packages = base_registry + '/packages'
 
     pkg_info = []
 
@@ -298,9 +297,9 @@ def list_packages(registry=None):
                 pkg = Package.browse(name, pkg_hash=pkg_hash)
                 pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
-            for hash, ctime, size in zip(pkg_hashes, pkg_ctimes, pkg_sizes):
+            for top_hash, ctime, size in zip(pkg_hashes, pkg_ctimes, pkg_sizes):
                 pkg_info.append(
-                    {'pkg_name': pkg_name, 'hash': hash, 'ctime': ctime, 'size': size}
+                    {'pkg_name': pkg_name, 'top_hash': top_hash, 'ctime': ctime, 'size': size}
                 )
 
     elif registry_url.scheme == 's3':
@@ -372,9 +371,9 @@ def list_packages(registry=None):
                     )
                     pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
-                for hash, ctime, size in zip(pkg_hashes, pkg_ctimes, pkg_sizes):
+                for top_hash, ctime, size in zip(pkg_hashes, pkg_ctimes, pkg_sizes):
                     pkg_info.append(
-                        {'pkg_name': pkg_name, 'hash': hash, 'ctime': ctime, 'size': size}
+                        {'pkg_name': pkg_name, 'top_hash': top_hash, 'ctime': ctime, 'size': size}
                     )
 
     else:

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -2,16 +2,18 @@ import json
 import re
 from six.moves import urllib
 from urllib.parse import urlparse, unquote
+import datetime
+import pytz
 
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 import requests
-import arrow
+import humanize
 
 from .data_transfer import (copy_file, get_bytes, put_bytes, delete_object, list_objects,
                             list_object_versions, _update_credentials)
 from .formats import FormatRegistry
-from .packages import get_package_registry
+from .packages import get_package_registry, Package
 from .session import get_registry_url, get_session
 from .util import (HeliumConfig, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, fix_url, parse_file_url, parse_s3_url, read_yaml, validate_url,
@@ -231,39 +233,32 @@ def list_packages(registry=None):
         def _fmt_str(string, strlen):
             """Formats strings to a certain width"""
             if len(string) > strlen - 3:
-                return string[:strlen - 6] + '...' + '   '
+                return string[:strlen - 1] + '…'
             else:
-                return string.ljust(strlen)[:strlen - 3] + '   '
-
-        @staticmethod
-        def _humanize_bytesize(nbytes):
-            """Turns raw byte count into a human readable bytesize"""
-            suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-            i = 0
-            while nbytes >= 1024 and i < len(suffixes) - 1:
-                nbytes /= 1024
-                i += 1
-            filesize = (f'{nbytes:.2f}').rstrip('0').rstrip('.')
-            suffix = suffixes[i]
-            return f'{filesize} {suffix}'
+                return string.ljust(strlen)
 
         def create_str(self, pkg_info):
             """Generates a human-readable string representation of a registry"""
             if pkg_info:
-                pkg_name_display_width = max(max([len(info[0]) for info in pkg_info]), 30)
+                pkg_name_display_width = max(max([len(info[0]) for info in pkg_info]), 27)
             else:
-                pkg_name_display_width = 30
+                pkg_name_display_width = 27
 
-            out = (f"{self._fmt_str('PACKAGE', pkg_name_display_width)}"
-                   f"TOPHASH        "
-                   f"CREATED        "
-                   f"SIZE"
+            out = (f"{self._fmt_str('PACKAGE', pkg_name_display_width)}\t"
+                   f"{self._fmt_str('TOPHASH', 12)}\t"
+                   f"{self._fmt_str('CREATED', 12)}\t"
+                   f"{self._fmt_str('SIZE', 12)}\t"
                    f"\n")
             for name, tophash, ctime, size in pkg_info:
+                tdelta = datetime.datetime.now(pytz.utc) -\
+                    datetime.datetime.fromtimestamp(int(ctime), pytz.utc)
+                tdelta_str = humanize.naturaltime(tdelta)
+                size_str = humanize.naturalsize(size)
+
                 out += (f"{self._fmt_str(name, pkg_name_display_width)}"
                         f"{self._fmt_str(tophash[:12], 15)}"
-                        f"{self._fmt_str(arrow.get(ctime).humanize(), 15)}"
-                        f"{self._fmt_str(self._humanize_bytesize(size), 15).rstrip(' ')}\n")
+                        f"{self._fmt_str(tdelta_str, 15)}"
+                        f"{self._fmt_str(size_str, 15).rstrip(' ')}\n")
             return out
 
     base_registry = get_package_registry(fix_url(registry) if registry else None)
@@ -300,21 +295,11 @@ def list_packages(registry=None):
 
                 pkg_ctimes.append(pkg_hash_path.stat().st_ctime)
 
-                from t4 import Package
                 pkg = Package.browse(name, pkg_hash=pkg_hash)
                 pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
             pkg_info += [(pkg_name, hash, ctime, size) for (hash, ctime, size) in
                          zip(pkg_hashes, pkg_ctimes, pkg_sizes)]
-
-        def sorter(pkg_info_tup):
-            pkg_name, pkg_cdate = pkg_info_tup[0], pkg_info_tup[2]
-            is_latest = ':latest' in pkg_name
-            pkg_realname = pkg_name.replace(':latest', '')
-            return (pkg_realname, not is_latest, -pkg_cdate)
-
-        pkg_info = sorted(pkg_info, key=sorter)
-        return PackageList(pkg_info)
 
     elif registry_url.scheme == 's3':
         bucket_name, bucket_registry_path, _ = parse_s3_url(registry_url)
@@ -380,7 +365,6 @@ def list_packages(registry=None):
                     pkg_names.append(pkg_name)
                     pkg_hashes.append(pkg_hash)
 
-                    from t4 import Package
                     pkg = Package.browse(
                         pkg_name, pkg_hash=pkg_hash, registry='s3://' + bucket_name
                     )
@@ -389,11 +373,17 @@ def list_packages(registry=None):
                 pkg_info += [(pkg_name, hash, ctime, size) for (pkg_name, hash, ctime, size) in
                              zip(pkg_names, pkg_hashes, pkg_ctimes, pkg_sizes)]
 
-        return PackageList(pkg_info)
-
     else:
         raise NotImplementedError
 
+    def sorter(pkg_info_tup):
+        pkg_name, pkg_cdate = pkg_info_tup[0], pkg_info_tup[2]
+        is_latest = ':latest' in pkg_name
+        pkg_realname = pkg_name.replace(':latest', '')
+        return (pkg_realname, not is_latest, -pkg_cdate)
+
+    pkg_info = sorted(pkg_info, key=sorter)
+    return PackageList(pkg_info)
 
 
 ########################################

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -212,7 +212,7 @@ def list_packages(registry=None):
         """Display wrapper for list_packages"""
 
         def __init__(self, pkg_info):
-            self.pkg_info = pkg_info
+            self.pkg_names = [info[0] for info in pkg_info]            
 
         def __repr__(self):
             if not hasattr(self, '_repr'):
@@ -221,7 +221,13 @@ def list_packages(registry=None):
             return self._repr
 
         def __iter__(self):
-            return iter([info[0] for info in self.pkg_info])
+            return iter(self.pkg_names)
+
+        def __len__(self):
+            return len(self.pkg_names)
+
+        def __contains__(self, item):
+            return item in self.pkg_names
 
         @staticmethod
         def _fmt_str(string, strlen):

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -283,16 +283,19 @@ def list_packages(registry=None):
             pkg_sizes = []
             pkg_ctimes = []
             pkg_name = name
-            latest_hash = None
+
+            with open(named_path / 'latest', 'r') as latest_hash_file:
+                latest_hash = latest_hash_file.read()
+
             for pkg_hash_path in named_path.rglob('*/'):
+                if pkg_hash_path.name == 'latest':
+                    continue
+
                 with open(pkg_hash_path, 'r') as pkg_hash_file:
                     pkg_hash = pkg_hash_file.read()
                     pkg_hashes.append(pkg_hash)
 
-                if pkg_hash_path.name == 'latest':
-                    latest_hash = pkg_hash
-                    continue
-                elif pkg_hash == latest_hash:
+                if pkg_hash == latest_hash:
                     pkg_name = f'{pkg_name}:latest'
 
                 pkg_ctimes.append(pkg_hash_path.stat().st_ctime)
@@ -301,7 +304,7 @@ def list_packages(registry=None):
                 pkg = Package.browse(name, pkg_hash=pkg_hash)
                 pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
 
-            pkg_info += [[pkg_name, hash, ctime, size] for (hash, ctime, size) in
+            pkg_info += [(pkg_name, hash, ctime, size) for (hash, ctime, size) in
                          zip(pkg_hashes, pkg_ctimes, pkg_sizes)]
 
         def sorter(pkg_info_tup):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -649,6 +649,7 @@ def test_list_remote_packages():
         else:
             raise ValueError
 
+    # TODO: do not check CREATED to avoid impropriety in case of local editing
     with patch('t4.api.list_objects', side_effect=pseudo_list_objects), \
         patch('t4.api.get_bytes', return_value=(b'100', None)), \
         patch('t4.Package.browse', return_value=Package()):
@@ -657,11 +658,11 @@ def test_list_remote_packages():
         assert len(pkgs) == 1
         assert list(pkgs) == ['foo/bar']
 
-        expected = (
-            'PACKAGE                       TOPHASH        CREATED        SIZE\n'
-            'foo/bar:latest                100            just now       0 B\n'
-        )
-        assert str(pkgs) == expected
+        # expected = (
+        #     'PACKAGE                       TOPHASH        CREATED        SIZE\n'
+        #     'foo/bar:latest                100            now            0 Bytes\n'
+        # )
+        # assert str(pkgs) == expected
 
 
 def test_validate_package_name():

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -505,6 +505,15 @@ def test_list_local_packages(tmpdir):
         assert "Quilt/Foo" in pkgs
         assert "Quilt/Bar" in pkgs
 
+        # Verify package repr is as expected.
+        expected = (
+            'PACKAGE                       TOPHASH        CREATED        SIZE\n'
+            'Quilt/Test:latest             2a5a67156ca9   just now       0 B\n'
+            'Quilt/Foo:latest              2a5a67156ca9   just now       0 B\n'
+            'Quilt/Bar:latest              2a5a67156ca9   just now       0 B\n'
+        )
+        assert expected == str(t4.list_packages())
+
         # Test unnamed packages are not added.
         Package().build()
         pkgs = t4.list_packages()

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -630,15 +630,8 @@ def test_brackets():
         pkg[0]
 
 def test_list_remote_packages():
-    with patch('t4.api.list_objects',
-               return_value=([{'Prefix': 'foo'},{'Prefix': 'bar'}],[])) as mock:
-        pkgs = t4.list_packages('s3://my_test_bucket/')
-        assert mock.call_args_list[0][0] == ('my_test_bucket', '.quilt/named_packages/')
-
-    assert True
-
-
-def test_list_remote_packages_repr():
+    # with patch('t4.api.list_objects',
+    #            return_value=([{'Prefix': 'foo'},{'Prefix': 'bar'}],[])) as mock:
     def pseudo_list_objects(bucket, prefix, recursive):
         if prefix == '.quilt/named_packages/':
             return ([{'Prefix': '.quilt/named_packages/foo/'}], [])
@@ -660,6 +653,10 @@ def test_list_remote_packages_repr():
         patch('t4.api.get_bytes', return_value=(b'100', None)), \
         patch('t4.Package.browse', return_value=Package()):
         pkgs = t4.list_packages('s3://my_test_bucket/')
+
+        assert len(pkgs) == 1
+        assert list(pkgs) == ['foo/bar']
+
         expected = (
             'PACKAGE                       TOPHASH        CREATED        SIZE\n'
             'foo/bar:latest                100            just now       0 B\n'

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -649,7 +649,6 @@ def test_list_remote_packages():
         else:
             raise ValueError
 
-    # TODO: do not check CREATED to avoid impropriety in case of local editing
     with patch('t4.api.list_objects', side_effect=pseudo_list_objects), \
         patch('t4.api.get_bytes', return_value=(b'100', None)), \
         patch('t4.Package.browse', return_value=Package()):
@@ -658,11 +657,11 @@ def test_list_remote_packages():
         assert len(pkgs) == 1
         assert list(pkgs) == ['foo/bar']
 
-        # expected = (
-        #     'PACKAGE                       TOPHASH        CREATED        SIZE\n'
-        #     'foo/bar:latest                100            now            0 Bytes\n'
-        # )
-        # assert str(pkgs) == expected
+        expected = (
+            'PACKAGE                    \tTOPHASH     \tCREATED     \tSIZE        \t\n'
+            'foo/bar:latest             \t100            \tnow            \t0 Bytes\t\n'
+        )
+        assert str(pkgs) == expected
 
 
 def test_validate_package_name():

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -121,13 +121,14 @@ To see all the packages available on a catalog, use `list_packages`:
 
 ```python
 t4.list_packages('s3://your-bucket')
-# outputs ['username/packagename', 'foo/bar']
+PACKAGE                           TOPHASH        CREATED        SIZE
+username/packagename:latest       cac145b9c3dc   just now       2.4 GB
 ```
 
 To download a package and all of its data from a remote catalog to a `dest` on your machine, `install` it.
 
 ```python
-p = t4.Package.install('username/packagename', 's3://your-bucket', dest='temp_folder/')
+p = t4.Package.install('username/packagename', 's3://your-bucket', dest='./')
 ```
 
 You can also choose to download just the  **package manifest** without downloading the data files it references. A package manifest is a simple JSON metadata file that is independent of the actual package data:

--- a/docs/Walkthrough/Installing a Package.md
+++ b/docs/Walkthrough/Installing a Package.md
@@ -8,11 +8,15 @@ $ python
 
 >>> t4.list_packages()  # list local packages
 
-["namespace/packagename", "othernamespace/otherpackagename"]
+PACKAGE                            TOPHASH        CREATED        SIZE
+namespace/packagename:latest       cac145b9c3dc   just now       2.4 GB
+othernamespace/packagename:latest  95a134c80z48   14 days ago    2.4 GB
 
 >>> t4.list_packages("s3://my-bucket")  # list remote packages
 
-["user1/seattle-weather", "user2/new-york-ballgames", ...]
+PACKAGE                            TOPHASH        CREATED        SIZE
+user1/seattle-weather:latest       cac145b9c3dc   1 hour ago     2.4 GB
+user2/new-york-ballgames:latest    95a134c80z48   6 days ago     2.4 GB
 ```
 
 ## Installing a package


### PR DESCRIPTION
This PR improves the `t4.list_packages` interface.

TLDR old behavior:
```python
['akarve/sample_jupyter_notebooks',
 'aleksey/fashion_mnist',
 'aleksey/hurdat',
 'quilt/open_images',
 'robnewman/honey_bees',
 'robnewman/us_county_smoking_vs_poverty']
```

New behavior:

```python
PACKAGE                                      TOPHASH        CREATED        SIZE
akarve/sample_jupyter_notebooks:latest       cac145b9c3dc   13 days ago    2.4 GB
aleksey/fashion_mnist:latest                 d6cff331b9e5   8 minutes...   126.88 MB
aleksey/hurdat:latest                        83777d50fc6d   16 days ago    79.15 KB
quilt/open_images:latest                     046071fa2104   a month ago    5.76 GB
robnewman/honey_bees:latest                  724f3dbff5c6   16 days ago    12.58 MB
robnewman/us_county_smoking_vs_poverty:...   704da7d9ed70   16 days ago    1.6 MB
```

Behavior for `list(t4.list_packages())` is the old behavior:

```python
['akarve/sample_jupyter_notebooks',
 'aleksey/fashion_mnist',
 'aleksey/hurdat',
 'quilt/open_images',
 'robnewman/honey_bees',
 'robnewman/us_county_smoking_vs_poverty']
```

Notes:
* <s>There is a new project dependency, `arrow`, a datetime library that I used to humanize the dates.</s> (now `humanize`)
* This required injecting a `PackageList` class into the `list_packages` function.
* The logic involved is took more LOC than I anticipated.