### PR TITLE
Make entry optional in set and set_dir

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -523,7 +523,7 @@ class Package(object):
 
         return pkg
 
-    def set_dir(self, lkey, path, meta=None):
+    def set_dir(self, lkey, path=None, meta=None):
         """
         Adds all files from `path` to the package.
 
@@ -534,6 +534,7 @@ class Package(object):
             lkey(string): prefix to add to every logical key,
                 use '/' for the root of the package.
             path(string): path to scan for files to add to package.
+                If None, lkey will be substituted in as the path.
             meta(dict): user level metadata dict to attach to lkey directory entry.
 
         Returns:
@@ -543,9 +544,14 @@ class Package(object):
             When `path` doesn't exist
         """
         lkey = lkey.strip("/")
-        root = self._ensure_subpackage(self._split_key(lkey)) if lkey else self
 
+        root = self._ensure_subpackage(self._split_key(lkey)) if lkey else self
         root.set_meta(meta)
+
+        if not path:
+            current_working_dir = pathlib.Path.cwd()
+            logical_key_abs_path = pathlib.Path(lkey).absolute()
+            path = logical_key_abs_path.relative_to(current_working_dir)
 
         # TODO: deserialization metadata
         url = urlparse(fix_url(path).strip('/'))
@@ -743,14 +749,15 @@ class Package(object):
             self.set(prefix + logical_key, entry, meta)
         return self
 
-    def set(self, logical_key, entry, meta=None):
+    def set(self, logical_key, entry=None, meta=None):
         """
         Returns self with the object at logical_key set to entry.
 
         Args:
             logical_key(string): logical key to update
-            entry(PackageEntry OR string): new entry to place at logical_key in the package
-                if entry is a string, it is treated as a URL, and an entry is created based on it
+            entry(PackageEntry OR string): new entry to place at logical_key in the package.
+                If entry is a string, it is treated as a URL, and an entry is created based on it.
+                If entry is None, the logical key string will be substituted as the entry value.
             meta(dict): user level metadata dict to attach to entry
 
         Returns:
@@ -758,6 +765,11 @@ class Package(object):
         """
         if not logical_key or logical_key.endswith('/'):
             raise QuiltException("Invalid logical_key: %r; cannot be a directory" % logical_key)
+
+        if not entry:
+            current_working_dir = pathlib.Path.cwd()
+            logical_key_abs_path = pathlib.Path(logical_key).absolute()
+            entry = logical_key_abs_path.relative_to(current_working_dir)
 
         if isinstance(entry, (string_types, getattr(os, 'PathLike', str))):
             url = fix_url(str(entry))

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -410,6 +410,13 @@ def test_local_set_dir(tmpdir):
     assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_keys[0]
     assert pkg['new_dir'].get_meta() == "new_test_meta"
 
+    # verify set_dir logical key shortcut
+    pkg = Package()
+    pkg.set_dir("/")
+    assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
+    assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
+
+
 def test_s3_set_dir(tmpdir):
     """ Verify building a package from an S3 directory. """
     with patch('t4.packages.list_object_versions') as list_object_versions_mock:
@@ -540,6 +547,10 @@ def test_set_package_entry(tmpdir):
     pkg['bar'].set('bar.txt')
 
     assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+
+    # Test shortcut codepath
+    pkg = Package().set('bar.txt')
+    assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_keys[0]
 
 def test_tophash_changes(tmpdir):
     test_file = tmpdir / 'test.txt'


### PR DESCRIPTION
The most common usage pattern for using `t4.Package.set` and `t4.Package.set_dir` is to align a logical key with an entry key:

```python
t4.Package().set_dir("foo/", "foo/").set("bar", "bar")
```

This PR provides a syntactic shortcut that eliminates the need for the doubled argument. You now get the same behavior with:

```python
t4.Package().set_dir("foo/").set("bar")
```

It's been obvious for a while now that this is a QOL improvement that we maybe should have started out with. 😅