### PR TITLE
Use top_hash everywhere

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -303,7 +303,7 @@ class Package(object):
         return repr_str
 
     @classmethod
-    def install(cls, name, registry=None, pkg_hash=None, dest=None, dest_registry=None):
+    def install(cls, name, registry=None, top_hash=None, dest=None, dest_registry=None):
         """
         Installs a named package to the local registry and downloads its files.
 
@@ -311,7 +311,7 @@ class Package(object):
             name(str): Name of package to install.
             registry(str): Registry where package is located. 
                 Defaults to the default remote registry.
-            pkg_hash(str): Hash of package to install. Defaults to latest.
+            top_hash(str): Hash of package to install. Defaults to latest.
             dest(str): Local path to download files to.
             dest_registry(str): Registry to install package to. Defaults to local registry.
 
@@ -326,11 +326,11 @@ class Package(object):
                                      "or configure a default remote registry with t4.config")
         elif registry == 'local':
             registry = get_from_config('default_local_registry')
-        
+
         if dest_registry is None:
             dest_registry = get_from_config('default_local_registry')
 
-        pkg = cls.browse(name=name, registry=registry, pkg_hash=pkg_hash)
+        pkg = cls.browse(name=name, registry=registry, top_hash=top_hash)
 
         if dest is None:
             dest = get_install_location()
@@ -339,14 +339,14 @@ class Package(object):
 
 
     @classmethod
-    def browse(cls, name=None, registry=None, pkg_hash=None):
+    def browse(cls, name=None, registry=None, top_hash=None):
         """
         Load a package into memory from a registry without making a local copy of
         the manifest.
         Args:
             name(string): name of package to load
             registry(string): location of registry to load package from
-            pkg_hash(string): top hash of package version to load
+            top_hash(string): top hash of package version to load
         """
         if registry is None:
             # use default remote registry if present
@@ -354,9 +354,9 @@ class Package(object):
 
         registry_prefix = get_package_registry(fix_url(registry) if registry else None)
 
-        if pkg_hash is not None:
+        if top_hash is not None:
             # If hash is specified, name doesn't matter.
-            pkg_path = '{}/packages/{}'.format(registry_prefix, pkg_hash)
+            pkg_path = '{}/packages/{}'.format(registry_prefix, top_hash)
             return cls._from_path(pkg_path)
         else:
             validate_package_name(name)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -119,7 +119,7 @@ def test_default_registry(tmpdir):
             assert pkg['bar'].physical_keys[0].endswith('.quilttest/Quilt/Test/bar')
 
 @patch('appdirs.user_data_dir', lambda x,y: os.path.join('test_appdir', x))
-@patch('t4.Package.browse', lambda name, registry, pkg_hash: Package())
+@patch('t4.Package.browse', lambda name, registry, top_hash: Package())
 def test_default_install_location(tmpdir):
     """Verify that pushes to the default local install location work as expected"""
     with patch('t4.Package.push') as push_mock:
@@ -170,46 +170,46 @@ def test_browse_package_from_registry():
         registry = BASE_PATH.as_uri()
         pkg = Package()
         pkgmock.return_value = pkg
-        pkghash = pkg.top_hash()
+        top_hash = pkg.top_hash()
 
         # default registry load
-        pkg = Package.browse(pkg_hash=pkghash)
-        assert '{}/.quilt/packages/{}'.format(registry, pkghash) \
+        pkg = Package.browse(top_hash=top_hash)
+        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
 
-        pkg = Package.browse('Quilt/nice-name', pkg_hash=pkghash)
-        assert '{}/.quilt/packages/{}'.format(registry, pkghash) \
+        pkg = Package.browse('Quilt/nice-name', top_hash=top_hash)
+        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
 
         with patch('t4.packages.get_bytes') as dl_mock:
-            dl_mock.return_value = (pkghash.encode('utf-8'), None)
+            dl_mock.return_value = (top_hash.encode('utf-8'), None)
             pkg = Package.browse('Quilt/nice-name')
             assert registry + '/.quilt/named_packages/Quilt/nice-name/latest' \
                     == dl_mock.call_args_list[0][0][0]
 
-        assert '{}/.quilt/packages/{}'.format(registry, pkghash) \
+        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
         pkgmock.reset_mock()
 
         remote_registry = 's3://asdf/foo'
         # remote load
-        pkg = Package.browse('Quilt/nice-name', registry=remote_registry, pkg_hash=pkghash)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, pkghash) \
+        pkg = Package.browse('Quilt/nice-name', registry=remote_registry, top_hash=top_hash)
+        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
         pkgmock.reset_mock()
-        pkg = Package.browse(pkg_hash=pkghash, registry=remote_registry)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, pkghash) \
+        pkg = Package.browse(top_hash=top_hash, registry=remote_registry)
+        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
         with patch('t4.packages.get_bytes') as dl_mock:
-            dl_mock.return_value = (pkghash.encode('utf-8'), None)
+            dl_mock.return_value = (top_hash.encode('utf-8'), None)
             pkg = Package.browse('Quilt/nice-name', registry=remote_registry)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, pkghash) \
+        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
 def test_local_install(tmpdir):
@@ -704,12 +704,12 @@ def test_top_hash_stable():
     """Ensure that top_hash() never changes for a given manifest"""
 
     registry = Path(__file__).parent / 'data'
-    pkg_hash = '20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733'
+    top_hash = '20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733'
 
-    pkg = Package.browse(registry=registry, pkg_hash=pkg_hash)
+    pkg = Package.browse(registry=registry, top_hash=top_hash)
 
-    assert pkg.top_hash() == pkg_hash, \
-           "Unexpected top_hash for {}/.quilt/packages/{}".format(registry, pkg_hash)
+    assert pkg.top_hash() == top_hash, \
+           "Unexpected top_hash for {}/.quilt/packages/{}".format(registry, top_hash)
 
 
 @patch('appdirs.user_data_dir', lambda x, y: os.path.join('test_appdir', x))
@@ -894,7 +894,7 @@ def test_manifest():
     top_hash = pkg.build()
     manifest = list(pkg.manifest)
 
-    pkg2 = Package.browse(pkg_hash=top_hash)
+    pkg2 = Package.browse(top_hash=top_hash)
     assert list(pkg.manifest) == list(pkg2.manifest)
 
 

--- a/docs/API Reference/Package.md
+++ b/docs/API Reference/Package.md
@@ -12,7 +12,7 @@ Provides a generator of the dicts that make up the serialied package.
 String representation of the Package.
 
 
-## Package.install(name, registry=None, pkg\_hash=None, dest=None, dest\_registry=None)  {#Package.install}
+## Package.install(name, registry=None, top\_hash=None, dest=None, dest\_registry=None)  {#Package.install}
 
 Installs a named package to the local registry and downloads its files.
 
@@ -21,7 +21,7 @@ __Arguments__
 * __name(str)__:  Name of package to install.
 * __registry(str)__:  Registry where package is located.
     Defaults to the default remote registry.
-* __pkg_hash(str)__:  Hash of package to install. Defaults to latest.
+* __top_hash(str)__:  Hash of package to install. Defaults to latest.
 * __dest(str)__:  Local path to download files to.
 * __dest_registry(str)__:  Registry to install package to. Defaults to local registry.
 
@@ -30,7 +30,7 @@ __Returns__
 A new Package that points to files on your local machine.
 
 
-## Package.browse(name=None, registry=None, pkg\_hash=None)  {#Package.browse}
+## Package.browse(name=None, registry=None, top\_hash=None)  {#Package.browse}
 
 Load a package into memory from a registry without making a local copy of
 the manifest.
@@ -38,7 +38,7 @@ __Arguments__
 
 * __name(string)__:  name of package to load
 * __registry(string)__:  location of registry to load package from
-* __pkg_hash(string)__:  top hash of package version to load
+* __top_hash(string)__:  top hash of package version to load
 
 
 ## Package.\_\_contains\_\_(self, logical\_key)  {#Package.\_\_contains\_\_}

--- a/docs/Walkthrough/Distributing a Package.md
+++ b/docs/Walkthrough/Distributing a Package.md
@@ -8,7 +8,7 @@ To save a package to local disk use `build`.
 import t4
 p = t4.Package()
 
-tophash = p.build("username/packagename")
+top_hash = p.build("username/packagename")
 ```
 
 Building a package requires providing it with a name. Packages names must follow the `${namespace}/${packagename}` format. For small teams, we recommend using the package author's name as the namespace.
@@ -39,7 +39,7 @@ The default remote registry, if set, persists between sessions.
 
 ## Distributing a package version
 
-A successful package `build` or `push` returns a **tophash**.
+A successful package `build` or `push` returns a **top hash**.
 
 ```bash
 $ python
@@ -48,7 +48,7 @@ $ python
 '2a5a67156ca9238c14d12042db51c5b52260fdd5511b61ea89b58929d6e1769b'
 ```
 
-A tophash is a persistent, immutable reference to a specific version of a package. To download this specific version of the package in the future you will need to provide this tophash.
+A top hash is a persistent, immutable reference to a specific version of a package. To download this specific version of the package in the future you will need to provide this top hash.
 
 ## Delete a package from a registry
 

--- a/docs/Walkthrough/Installing a Package.md
+++ b/docs/Walkthrough/Installing a Package.md
@@ -44,10 +44,10 @@ Data files that you download are written to a folder in your local registry by d
 t4.Package.install("username/packagename", dest="./")
 ```
 
-Finally, you can install a specific version of a package by specifying the corresponding tophash:
+Finally, you can install a specific version of a package by specifying the corresponding top hash:
 
 ```python
-t4.Package.install("username/packagename", pkg_hash="abcd1234")
+t4.Package.install("username/packagename", top_hash="abcd1234")
 ```
 
 ## Browsing a package manifest


### PR DESCRIPTION
We use, variously, "tophash", "top hash"/`top_hash`, and `pkg_hash` in the code and docs. We've agreed on using "top hash"/`top_hash`. This PR unifies the names in the code/docs.