### PR TITLE
t4.Package.browse now respects default_remote_registry by default

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -349,7 +349,12 @@ class Package(object):
             top_hash(string): top hash of package version to load
         """
         if registry is None:
-            # use default remote registry if present
+            registry = get_from_config('default_remote_registry')
+            if registry is None:
+                raise QuiltException("No registry specified and no default remote "
+                                     "registry configured. Please specify a registry "
+                                     "or configure a default remote registry with t4.config")
+        elif registry == 'local':
             registry = get_from_config('default_local_registry')
 
         registry_prefix = get_package_registry(fix_url(registry) if registry else None)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -212,6 +212,11 @@ def test_browse_package_from_registry():
         assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
+        # default remote registry failure case
+        with patch('t4.packages.get_from_config', return_value=None):
+            with pytest.raises(QuiltException):
+                Package.browse('Quilt/nice-name')
+
 def test_local_install(tmpdir):
     """Verify that installing from a local package works as expected."""
     with patch('t4.packages.get_from_config') as get_config_mock, \

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -172,14 +172,14 @@ def test_browse_package_from_registry():
         pkgmock.return_value = pkg
         top_hash = pkg.top_hash()
 
-        # default registry load
-        pkg = Package.browse(top_hash=top_hash)
+        # local registry load
+        pkg = Package.browse(registry='local', top_hash=top_hash)
         assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
         pkgmock.reset_mock()
 
-        pkg = Package.browse('Quilt/nice-name', top_hash=top_hash)
+        pkg = Package.browse('Quilt/nice-name', registry='local', top_hash=top_hash)
         assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
                 in [x[0][0] for x in pkgmock.call_args_list]
 
@@ -187,7 +187,7 @@ def test_browse_package_from_registry():
 
         with patch('t4.packages.get_bytes') as dl_mock:
             dl_mock.return_value = (top_hash.encode('utf-8'), None)
-            pkg = Package.browse('Quilt/nice-name')
+            pkg = Package.browse('Quilt/nice-name', registry='local')
             assert registry + '/.quilt/named_packages/Quilt/nice-name/latest' \
                     == dl_mock.call_args_list[0][0][0]
 
@@ -669,8 +669,8 @@ def test_diff():
     new_pkg = new_pkg.set('foo', test_file_name)
     top_hash = new_pkg.build("Quilt/Test")
 
-    p1 = Package.browse('Quilt/Test')
-    p2 = Package.browse('Quilt/Test')
+    p1 = Package.browse('Quilt/Test', registry='local')
+    p2 = Package.browse('Quilt/Test', registry='local')
     assert p1.diff(p2) == ([], [], [])
 
 
@@ -894,7 +894,7 @@ def test_manifest():
     top_hash = pkg.build()
     manifest = list(pkg.manifest)
 
-    pkg2 = Package.browse(top_hash=top_hash)
+    pkg2 = Package.browse(top_hash=top_hash, registry='local')
     assert list(pkg.manifest) == list(pkg2.manifest)
 
 

--- a/docs/Walkthrough/Installing a Package.md
+++ b/docs/Walkthrough/Installing a Package.md
@@ -57,11 +57,14 @@ An alternative to `install` is `browse`. `browse` downloads a package manifest w
 ```python
 import t4
 
-# load a package manifest from the local registry
+# load a package manifest from a remote registry
+p  = t4.Package.browse("username/packagename", "s3://your-bucket")
+
+# load a package manifest from the default remote registry
 p  = t4.Package.browse("username/packagename")
 
-# load a package manifest from a remote registry
-p = t4.Package.browse("username/packagename", "s3://your-bucket")
+# load a package manifest from the local registry
+p = t4.Package.browse("username/packagename", "local")
 ```
 
 `browse` is advantageous when you don't want to download everything in a package at once. For example if you just want to look at a package's metadata.


### PR DESCRIPTION
This is a change in behavior that simplifies the user's mental model for working with packages by unifying how `install` and `browse` behave w.r.t. parameterization and the special `"local"` keyword.

TODO: test case and <s>update docs</s>.