### PR TITLE
Use copy_files instead of copy_file in t4.Package.fetch

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -441,8 +441,15 @@ class Package(object):
         """
         # TODO: do this with improved parallelism? connections etc. could be reused
         nice_dest = fix_url(dest).rstrip('/')
+
+        file_list = []
         for logical_key, entry in self.walk():
-            entry.fetch('{}/{}'.format(nice_dest, quote(logical_key)))
+            physical_key = _to_singleton(entry.physical_keys)
+            new_physical_key = f'{nice_dest}/{logical_key}'
+            entry_meta = entry.meta
+            file_list.append((physical_key, new_physical_key, entry_meta))
+
+        copy_file_list(file_list)
 
     def keys(self):
         """

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -439,11 +439,11 @@ class Package(object):
         Returns:
             None
         """
-        # TODO: do this with improved parallelism? connections etc. could be reused
         nice_dest = fix_url(dest).rstrip('/')
-
         file_list = []
+        
         for logical_key, entry in self.walk():
+            logical_key = quote(logical_key)
             physical_key = _to_singleton(entry.physical_keys)
             new_physical_key = f'{nice_dest}/{logical_key}'
             entry_meta = entry.meta


### PR DESCRIPTION
Using `copy_files` instead of `copy_file` in `t4.Package.fetch` solves two issues:

* It consolidates the as-many-progress-bars-as-there-are-files into a single progress bar, so if you, like me, want to push around 30,000 images, you no longer have to also push around 30,000 progress bars.
* It greatly speeds up downloads, as these may now be threaded (they're no longer sequential).

This was marked a TODO in the code. I need this because it creates sanity in a current project.

This fix *does* introduce another issue:
* There is an issue where if there are a lot of files `fetch` will appear to hang for a while without doing anything. A bug for this is already filed. This problem occurs because `copy_objects` has an intermediate step in between hashing and downloading: HEAD-ing the object for its size (or whatever the S3 equivalent is). If there's a lot of objects, there's a lot of HEAD requests...you were already paying this cost, but it's now more visible to the user.