### PR TITLE
Catalog: update preview logic (VCF, text, Excel)

### DIFF
--- a/catalog/app/app.js
+++ b/catalog/app/app.js
@@ -130,6 +130,7 @@ const render = (messages) => {
   );
 };
 
+/*
 if (module.hot) {
   // Hot reloadable React components and translation json files
   // modules.hot.accept does not accept dynamic dependencies,
@@ -139,6 +140,7 @@ if (module.hot) {
     render(translationMessages);
   });
 }
+*/
 
 // Chunked polyfill for browsers without Intl support
 if (!window.Intl) {

--- a/catalog/app/components/Preview/Preview.js
+++ b/catalog/app/components/Preview/Preview.js
@@ -19,6 +19,7 @@ const loaderChain = [
   loaders.Markdown,
   loaders.Notebook,
   loaders.Parquet,
+  loaders.Vcf,
   loaders.Text,
   loaders.Image,
   fallback,

--- a/catalog/app/components/Preview/Preview.js
+++ b/catalog/app/components/Preview/Preview.js
@@ -15,6 +15,7 @@ const fallback = {
 };
 
 const loaderChain = [
+  loaders.Csv,
   loaders.Json,
   loaders.Markdown,
   loaders.Notebook,

--- a/catalog/app/components/Preview/Preview.js
+++ b/catalog/app/components/Preview/Preview.js
@@ -16,6 +16,7 @@ const fallback = {
 
 const loaderChain = [
   loaders.Csv,
+  loaders.Excel,
   loaders.Json,
   loaders.Markdown,
   loaders.Notebook,

--- a/catalog/app/components/Preview/loaders/Csv.js
+++ b/catalog/app/components/Preview/loaders/Csv.js
@@ -1,0 +1,18 @@
+import parse from 'csv-parse/lib/es5/sync';
+
+import AsyncResult from 'utils/AsyncResult';
+
+import { PreviewData } from '../types';
+import * as utils from './utils';
+
+
+export const detect = utils.extIn(['.csv', '.tsv']);
+
+export const load = utils.previewFetcher('txt', ({ info: { data } }, { handle }) => {
+  const opts = {
+    delimiter: handle.key.endsWith('tsv') ? '\t' : ',',
+  };
+  const head = parse(data.head.join('\n'), opts);
+  const tail = data.tail.length ? parse(data.tail.join('\n'), opts) : [];
+  return AsyncResult.Ok(PreviewData.Table({ head, tail }));
+});

--- a/catalog/app/components/Preview/loaders/Csv.js
+++ b/catalog/app/components/Preview/loaders/Csv.js
@@ -1,4 +1,5 @@
 import parse from 'csv-parse/lib/es5/sync';
+import * as R from 'ramda';
 
 import AsyncResult from 'utils/AsyncResult';
 
@@ -6,11 +7,12 @@ import { PreviewData } from '../types';
 import * as utils from './utils';
 
 
-export const detect = utils.extIn(['.csv', '.tsv']);
+export const detect = R.pipe(utils.stripCompression,
+  utils.extIn(['.csv', '.tsv']));
 
 export const load = utils.previewFetcher('txt', ({ info: { data } }, { handle }) => {
   const opts = {
-    delimiter: handle.key.endsWith('tsv') ? '\t' : ',',
+    delimiter: utils.stripCompression(handle.key).endsWith('tsv') ? '\t' : ',',
   };
   const head = parse(data.head.join('\n'), opts);
   const tail = data.tail.length ? parse(data.tail.join('\n'), opts) : [];

--- a/catalog/app/components/Preview/loaders/Excel.js
+++ b/catalog/app/components/Preview/loaders/Excel.js
@@ -6,7 +6,8 @@ import { PreviewData } from '../types';
 import * as utils from './utils';
 
 
-export const detect = R.pipe(utils.stripCompression, utils.extIs('.parquet'));
+export const detect = R.pipe(utils.stripCompression,
+  utils.extIn(['.xls', '.xlsx']));
 
-export const load = utils.previewFetcher('parquet', (json) =>
+export const load = utils.previewFetcher('excel', (json) =>
   AsyncResult.Ok(PreviewData.DataFrame({ preview: json.html })));

--- a/catalog/app/components/Preview/loaders/Image.js
+++ b/catalog/app/components/Preview/loaders/Image.js
@@ -1,3 +1,5 @@
+import AsyncResult from 'utils/AsyncResult';
+
 import { PreviewData } from '../types';
 
 import * as utils from './utils';
@@ -6,12 +8,5 @@ import * as utils from './utils';
 export const detect =
   utils.extIn(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp']);
 
-const sign = async ({ handle, signer }) =>
-  PreviewData.Image({ url: signer.getSignedS3URL(handle) });
-
-export const load = utils.gatedS3Request(({ handle, gated }, callback) =>
-  utils.withSigner((signer) =>
-    utils.withData(
-      { fetch: sign, params: { handle, signer }, noAutoFetch: gated },
-      callback,
-    )));
+export const load = (handle, callback) =>
+  callback(AsyncResult.Ok(AsyncResult.Ok(PreviewData.Image({ handle }))));

--- a/catalog/app/components/Preview/loaders/Notebook.js
+++ b/catalog/app/components/Preview/loaders/Notebook.js
@@ -35,7 +35,7 @@ const renderFragment = (f) => {
 
 const renderMath = R.pipe(split, R.into('', R.map(renderFragment)));
 
-export const detect = utils.extIs('.ipynb');
+export const detect = R.pipe(utils.stripCompression, utils.extIs('.ipynb'));
 
 export const load = utils.previewFetcher('ipynb', (json) =>
   AsyncResult.Ok(PreviewData.Notebook({ preview: renderMath(json.html) })));

--- a/catalog/app/components/Preview/loaders/Parquet.js
+++ b/catalog/app/components/Preview/loaders/Parquet.js
@@ -1,10 +1,12 @@
+import * as R from 'ramda';
+
 import AsyncResult from 'utils/AsyncResult';
 
 import { PreviewData } from '../types';
 import * as utils from './utils';
 
 
-export const detect = utils.extIs('.parquet');
+export const detect = R.pipe(utils.stripCompression, utils.extIs('.parquet'));
 
 export const load = utils.previewFetcher('parquet', (json) =>
   AsyncResult.Ok(PreviewData.Parquet({ preview: json.html })));

--- a/catalog/app/components/Preview/loaders/Text.js
+++ b/catalog/app/components/Preview/loaders/Text.js
@@ -51,6 +51,7 @@ const langPairs = Object.entries(LANGS);
 const findLang = R.pipe(
   basename,
   R.toLower,
+  utils.stripCompression,
   (name) => langPairs.find(([, re]) => re.test(name)),
 );
 

--- a/catalog/app/components/Preview/loaders/Vcf.js
+++ b/catalog/app/components/Preview/loaders/Vcf.js
@@ -4,7 +4,7 @@ import { PreviewData } from '../types';
 import * as utils from './utils';
 
 
-export const detect = utils.extIs('.vcf');
+export const detect = utils.extIn(['.vcf', '.vcf.gz']);
 
 export const load = utils.previewFetcher('vcf', ({ info: { data: d } }) =>
   AsyncResult.Ok(PreviewData.Vcf({

--- a/catalog/app/components/Preview/loaders/Vcf.js
+++ b/catalog/app/components/Preview/loaders/Vcf.js
@@ -1,0 +1,14 @@
+import AsyncResult from 'utils/AsyncResult';
+
+import { PreviewData } from '../types';
+import * as utils from './utils';
+
+
+export const detect = utils.extIs('.vcf');
+
+export const load = utils.previewFetcher('vcf', ({ info: { data: d } }) =>
+  AsyncResult.Ok(PreviewData.Vcf({
+    meta: d.meta,
+    header: d.header.map((row) => row.split('\t')),
+    data: d.data.map((row) => row.split('\t')),
+  })));

--- a/catalog/app/components/Preview/loaders/Vcf.js
+++ b/catalog/app/components/Preview/loaders/Vcf.js
@@ -1,10 +1,13 @@
+import * as R from 'ramda';
+
 import AsyncResult from 'utils/AsyncResult';
 
 import { PreviewData } from '../types';
 import * as utils from './utils';
 
 
-export const detect = utils.extIn(['.vcf', '.vcf.gz']);
+export const detect = R.pipe(utils.stripCompression,
+  utils.extIs('.vcf'));
 
 export const load = utils.previewFetcher('vcf', ({ info: { data: d } }) =>
   AsyncResult.Ok(PreviewData.Vcf({

--- a/catalog/app/components/Preview/loaders/index.js
+++ b/catalog/app/components/Preview/loaders/index.js
@@ -1,3 +1,4 @@
+import * as Csv from './Csv';
 import * as Image from './Image';
 import * as Json from './Json';
 import * as Markdown from './Markdown';
@@ -7,4 +8,4 @@ import * as Text from './Text';
 import * as Vcf from './Vcf';
 
 // eslint-disable-next-line object-curly-newline
-export { Image, Json, Markdown, Notebook, Parquet, Text, Vcf };
+export { Csv, Image, Json, Markdown, Notebook, Parquet, Text, Vcf };

--- a/catalog/app/components/Preview/loaders/index.js
+++ b/catalog/app/components/Preview/loaders/index.js
@@ -1,4 +1,5 @@
 import * as Csv from './Csv';
+import * as Excel from './Excel';
 import * as Image from './Image';
 import * as Json from './Json';
 import * as Markdown from './Markdown';
@@ -8,4 +9,4 @@ import * as Text from './Text';
 import * as Vcf from './Vcf';
 
 // eslint-disable-next-line object-curly-newline
-export { Csv, Image, Json, Markdown, Notebook, Parquet, Text, Vcf };
+export { Csv, Excel, Image, Json, Markdown, Notebook, Parquet, Text, Vcf };

--- a/catalog/app/components/Preview/loaders/index.js
+++ b/catalog/app/components/Preview/loaders/index.js
@@ -4,6 +4,7 @@ import * as Markdown from './Markdown';
 import * as Notebook from './Notebook';
 import * as Parquet from './Parquet';
 import * as Text from './Text';
+import * as Vcf from './Vcf';
 
 // eslint-disable-next-line object-curly-newline
-export { Image, Json, Markdown, Notebook, Parquet, Text };
+export { Image, Json, Markdown, Notebook, Parquet, Text, Vcf };

--- a/catalog/app/components/Preview/loaders/utils.js
+++ b/catalog/app/components/Preview/loaders/utils.js
@@ -85,6 +85,13 @@ export const gatedS3Request = (fetcher) => (handle, callback, extraParams) =>
       _: callback,
     })));
 
+const parseRange = (range) => {
+  if (!range) return undefined;
+  const m = range.match(/bytes \d+-\d+\/(\d+)$/);
+  if (!m) return undefined;
+  return Number(m[1]);
+};
+
 const getFirstBytes = (bytes) => async ({ s3, handle }) => {
   try {
     const res = await s3.getObject({
@@ -94,8 +101,7 @@ const getFirstBytes = (bytes) => async ({ s3, handle }) => {
       Range: `bytes=0-${bytes}`,
     }).promise();
     const firstBytes = res.Body.toString('utf-8');
-    // TODO: expose and parse res.ContentRange
-    const contentLength = 1;
+    const contentLength = parseRange(res.ContentRange) || 0;
     return { firstBytes, contentLength };
   } catch (e) {
     if (['NoSuchKey', 'NotFound'].includes(e.name)) {

--- a/catalog/app/components/Preview/loaders/utils.js
+++ b/catalog/app/components/Preview/loaders/utils.js
@@ -5,7 +5,6 @@ import * as React from 'react';
 
 import * as AWS from 'utils/AWS';
 import AsyncResult from 'utils/AsyncResult';
-import * as BucketConfig from 'utils/BucketConfig';
 import * as Config from 'utils/Config';
 import Data from 'utils/Data';
 import * as NamedRoutes from 'utils/NamedRoutes';
@@ -161,21 +160,7 @@ const withGatewayEndpoint = (callback) => (
     {AsyncResult.case({
       Err: R.pipe(AsyncResult.Err, callback),
       _: callback,
-      Ok: (config) => (
-        <BucketConfig.WithCurrentBucketConfig>
-          {AsyncResult.case({
-            Err: R.pipe(AsyncResult.Err, callback),
-            _: callback,
-            Ok: R.pipe(
-              (bucket) =>
-                (bucket && bucket.apiGatewayEndpoint)
-                  || config.apiGatewayEndpoint,
-              AsyncResult.Ok,
-              callback,
-            ),
-          })}
-        </BucketConfig.WithCurrentBucketConfig>
-      ),
+      Ok: R.pipe(R.prop('apiGatewayEndpoint'), AsyncResult.Ok, callback),
     })}
   </Config.Inject>
 );

--- a/catalog/app/components/Preview/renderers/DataFrame.js
+++ b/catalog/app/components/Preview/renderers/DataFrame.js
@@ -7,16 +7,18 @@ import { withStyles } from '@material-ui/styles';
 import * as RT from 'utils/reactTools';
 
 
-const Parquet = RT.composeComponent('Preview.renderers.Parquet',
+const DataFrame = RT.composeComponent('Preview.renderers.DataFrame',
   RC.setPropTypes({
     children: PT.string,
     className: PT.string,
   }),
   withStyles(({ palette, spacing: { unit } }) => ({
     root: {
-      overflow: 'auto',
       padding: unit,
       width: '100%',
+    },
+    wrapper: {
+      overflow: 'auto',
 
       '& table.dataframe': {
         border: 'none',
@@ -29,6 +31,9 @@ const Parquet = RT.composeComponent('Preview.renderers.Parquet',
         '& th, & td': {
           border: 'none',
           fontSize: 'small',
+          height: 3 * unit,
+          paddingLeft: unit,
+          paddingRight: unit,
         },
 
         '& td': {
@@ -38,13 +43,14 @@ const Parquet = RT.composeComponent('Preview.renderers.Parquet',
     },
   })),
   ({ classes, children, className, ...props } = {}) => (
-    <div
-      className={cx(className, classes.root)}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: children }}
-      {...props}
-    />
+    <div className={cx(className, classes.root)} {...props}>
+      <div
+        className={classes.wrapper}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: children }}
+      />
+    </div>
   ));
 
 export default ({ preview }, props) =>
-  <Parquet {...props}>{preview}</Parquet>;
+  <DataFrame {...props}>{preview}</DataFrame>;

--- a/catalog/app/components/Preview/renderers/Image.js
+++ b/catalog/app/components/Preview/renderers/Image.js
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import * as React from 'react';
 import { withStyles } from '@material-ui/styles';
 
+import Thumbnail from 'components/Thumbnail';
 import * as RT from 'utils/reactTools';
 
 
@@ -12,7 +13,14 @@ const Image = RT.composeComponent('Preview.renderers.Image',
       maxWidth: '100%',
     },
   })),
-  ({ classes, className, ...props }) =>
-    <img className={cx(className, classes.root)} alt="" {...props} />);
+  ({ handle, classes, className, ...props }) => (
+    <Thumbnail
+      handle={handle}
+      size="lg"
+      className={cx(className, classes.root)}
+      alt=""
+      {...props}
+    />
+  ));
 
-export default ({ url }, props) => <Image src={url} {...props} />;
+export default (img, props) => <Image {...img} {...props} />;

--- a/catalog/app/components/Preview/renderers/Table.js
+++ b/catalog/app/components/Preview/renderers/Table.js
@@ -1,0 +1,81 @@
+import cx from 'classnames';
+import * as React from 'react';
+import MuiTable from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import { makeStyles } from '@material-ui/styles';
+
+
+const useStyles = makeStyles((t) => ({
+  root: {
+    overflow: 'auto',
+    padding: t.spacing.unit * 1.5,
+  },
+  row: {
+    height: t.spacing.unit * 3,
+
+    '&:nth-child(even)': {
+      background: t.palette.grey[100],
+    },
+  },
+  cell: {
+    border: 'none',
+
+    '&, &:last-child': {
+      paddingLeft: t.spacing.unit,
+      paddingRight: t.spacing.unit,
+    },
+  },
+  skip: {
+    textAlign: 'center',
+  },
+}));
+
+// eslint-disable-next-line react/prop-types
+const Table = ({ head, tail, className, ...props }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={cx(className, classes.root)} {...props}>
+      <MuiTable>
+        <TableBody>
+          {head.map((row, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableRow key={`head:${i}`} className={classes.row}>
+              {row.map((col, j) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <TableCell key={`head:${i}:${j}`} className={classes.cell}>
+                  {col}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+          {!!tail.length && (
+            <TableRow key="skip" className={classes.row}>
+              <TableCell
+                colSpan={head[0].length}
+                className={cx(classes.cell, classes.skip)}
+              >
+                &hellip; rows skipped &hellip;
+              </TableCell>
+            </TableRow>
+          )}
+          {tail.map((row, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableRow key={`tail:${i}`} className={classes.row}>
+              {row.map((col, j) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <TableCell key={`tail:${i}:${j}`} className={classes.cell}>
+                  {col}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </MuiTable>
+    </div>
+  );
+};
+
+export default (table, props) => <Table {...table} {...props} />;

--- a/catalog/app/components/Preview/renderers/Text.js
+++ b/catalog/app/components/Preview/renderers/Text.js
@@ -10,7 +10,7 @@ import * as RT from 'utils/reactTools';
 const Text = RT.composeComponent('Preview.renderers.Text',
   RC.setPropTypes({
     className: PT.string,
-    children: PT.string,
+    children: PT.node,
   }),
   withStyles((t) => ({
     root: {
@@ -20,14 +20,20 @@ const Text = RT.composeComponent('Preview.renderers.Text',
       whiteSpace: 'pre',
     },
   })),
-  ({ classes, className, children, ...props }) => (
-    <div
-      className={cx(className, classes.root)}
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: children }}
-      {...props}
-    />
+  ({ classes, className, ...props }) => (
+    <div className={cx(className, classes.root)} {...props} />
   ));
 
-export default ({ highlighted }, props) =>
-  <Text {...props}>{highlighted}</Text>;
+const html = (contents) =>
+  // eslint-disable-next-line react/no-danger
+  <div dangerouslySetInnerHTML={{ __html: contents }} />;
+
+const Skip = () => <div>&hellip;</div>;
+
+export default ({ highlighted: { head, tail } }, props) => (
+  <Text {...props}>
+    {html(head)}
+    {!!tail && <Skip />}
+    {!!tail && html(tail)}
+  </Text>
+);

--- a/catalog/app/components/Preview/renderers/Vcf.js
+++ b/catalog/app/components/Preview/renderers/Vcf.js
@@ -1,0 +1,95 @@
+import cx from 'classnames';
+import * as React from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import { makeStyles } from '@material-ui/styles';
+
+
+const useStyles = makeStyles((t) => ({
+  root: {
+    overflow: 'auto',
+    padding: t.spacing.unit * 1.5,
+  },
+  table: {
+    fontFamily: t.typography.monospace.fontFamily,
+  },
+  row: {
+    height: t.spacing.unit * 3,
+  },
+  cell: {
+    border: 'none',
+
+    '&, &:last-child': {
+      paddingLeft: t.spacing.unit * 2,
+      paddingRight: 0,
+    },
+
+    '&:first-child': {
+      paddingLeft: 0,
+    },
+  },
+  meta: {
+    color: t.palette.text.hint,
+  },
+  header: {
+    color: t.palette.text.primary,
+    fontWeight: 600,
+  },
+}));
+
+// eslint-disable-next-line react/prop-types
+const Vcf = ({ meta, header, data }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Table className={classes.table}>
+        <TableHead>
+          {meta.map((l, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableRow key={`meta:${i}`} className={classes.row}>
+              <TableCell
+                colSpan={header[0].length}
+                className={cx(classes.cell, classes.meta)}
+              >
+                {l}
+              </TableCell>
+            </TableRow>
+          ))}
+          {header.map((row, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableRow key={`header:${i}`} className={classes.row}>
+              {row.map((col, j) => (
+                <TableCell
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`header:${i}:${j}`}
+                  className={cx(classes.cell, classes.header)}
+                >
+                  {col}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableHead>
+        <TableBody>
+          {data.map((row, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableRow key={`data:${i}`} className={classes.row}>
+              {row.map((col, j) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <TableCell key={`data:${i}:${j}`} className={classes.cell}>
+                  {col}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default (data, props) => <Vcf {...data} {...props} />;

--- a/catalog/app/components/Preview/renderers/index.js
+++ b/catalog/app/components/Preview/renderers/index.js
@@ -4,3 +4,4 @@ export { default as Notebook } from './Notebook';
 export { default as Parquet } from './Parquet';
 export { default as Text } from './Text';
 export { default as Vega } from './Vega';
+export { default as Vcf } from './Vcf';

--- a/catalog/app/components/Preview/renderers/index.js
+++ b/catalog/app/components/Preview/renderers/index.js
@@ -1,7 +1,7 @@
+export { default as DataFrame } from './DataFrame';
 export { default as Image } from './Image';
 export { default as Markdown } from './Markdown';
 export { default as Notebook } from './Notebook';
-export { default as Parquet } from './Parquet';
 export { default as Table } from './Table';
 export { default as Text } from './Text';
 export { default as Vega } from './Vega';

--- a/catalog/app/components/Preview/renderers/index.js
+++ b/catalog/app/components/Preview/renderers/index.js
@@ -2,6 +2,7 @@ export { default as Image } from './Image';
 export { default as Markdown } from './Markdown';
 export { default as Notebook } from './Notebook';
 export { default as Parquet } from './Parquet';
+export { default as Table } from './Table';
 export { default as Text } from './Text';
 export { default as Vega } from './Vega';
 export { default as Vcf } from './Vcf';

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -8,6 +8,7 @@ export const PreviewData = tagged([
   'Parquet', // { preview: string }
   'Notebook', // { preview: string }
   'Text', // { contents: string, lang: string }
+  'Vcf', // { meta: string[], header: string[][], body: string[][] }
 ]);
 
 export const PreviewError = tagged([

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -2,7 +2,7 @@ import tagged from 'utils/tagged';
 
 
 export const PreviewData = tagged([
-  'Image', // { url: string }
+  'Image', // { handle: object }
   'Markdown', // { rendered: string }
   'Vega', // { spec: Object }
   'Parquet', // { preview: string }

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -9,6 +9,7 @@ export const PreviewData = tagged([
   'Notebook', // { preview: string }
   'Text', // { contents: string, lang: string }
   'Vcf', // { meta: string[], header: string[][], body: string[][] }
+  'Table', // { head: string[], tail: string[] }
 ]);
 
 export const PreviewError = tagged([

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -2,14 +2,14 @@ import tagged from 'utils/tagged';
 
 
 export const PreviewData = tagged([
+  'DataFrame', // { preview: string }
   'Image', // { handle: object }
   'Markdown', // { rendered: string }
-  'Vega', // { spec: Object }
-  'Parquet', // { preview: string }
   'Notebook', // { preview: string }
+  'Table', // { head: string[], tail: string[] }
   'Text', // { contents: string, lang: string }
   'Vcf', // { meta: string[], header: string[][], body: string[][] }
-  'Table', // { head: string[], tail: string[] }
+  'Vega', // { spec: Object }
 ]);
 
 export const PreviewError = tagged([

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -16,4 +16,5 @@ export const PreviewError = tagged([
   'Unsupported', // { handle }
   'DoesNotExist', // { handle }
   'Unexpected', // { handle, originalError: any }
+  'MalformedJson', // { handle, originalError: SyntaxError }
 ]);

--- a/catalog/app/components/Thumbnail/Thumbnail.js
+++ b/catalog/app/components/Thumbnail/Thumbnail.js
@@ -1,15 +1,10 @@
 import PT from 'prop-types';
 import * as React from 'react';
 import * as RC from 'recompose';
-import { unstable_Box as Box } from '@material-ui/core/Box';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import Icon from '@material-ui/core/Icon';
 
 import * as AWS from 'utils/AWS';
 import { useConfig } from 'utils/Config';
-import { withBoundary } from 'utils/ErrorBoundary';
 import { mkSearch } from 'utils/NamedRoutes';
-import * as Cache from 'utils/ResourceCache';
 import * as RT from 'utils/reactTools';
 
 
@@ -20,40 +15,6 @@ const SIZES = {
 
 const sizeStr = (s) => `w${SIZES[s].w}h${SIZES[s].h}`;
 
-const ThumbnailResource = Cache.createResource({
-  name: 'Thumbnail',
-  fetch: async ({ api, sign, handle, size }) => {
-    const url = sign(handle);
-    const endpoint = `${api}/thumbnail${mkSearch({ url, size: sizeStr(size) })}`;
-    const r = await fetch(endpoint);
-    const json = await r.json();
-    const fmt = json.info.thumbnail_format.toLowerCase();
-    return `data:image/${fmt};base64, ${json.thumbnail}`;
-  },
-  key: ({ api, handle, size }) => ({ api, handle, size }),
-});
-
-export const use = ({ handle, size }) => {
-  const api = useConfig().apiGatewayEndpoint;
-  const sign = AWS.Signer.useS3Signer();
-  return Cache.useData(ThumbnailResource, { api, sign, handle, size },
-    { suspend: true });
-};
-
-// eslint-disable-next-line react/prop-types
-const Container = ({ size, children }) => (
-  <Box
-    display="flex"
-    alignItems="center"
-    justifyContent="center"
-    height={SIZES[size].h}
-    bgcolor="grey.100"
-    width={1}
-  >
-    {children}
-  </Box>
-);
-
 export default RT.composeComponent('Thumbnail',
   RC.setPropTypes({
     handle: PT.object.isRequired,
@@ -62,21 +23,11 @@ export default RT.composeComponent('Thumbnail',
   RC.defaultProps({
     size: 'sm',
   }),
-  withBoundary((props) => (error) => {
-    // eslint-disable-next-line no-console
-    console.warn('Error loading thumbnail', props);
-    // eslint-disable-next-line no-console
-    console.error(error);
-    return (
-      // eslint-disable-next-line react/prop-types
-      <Container size={props.size}>
-        <Icon fontSize="large" title="Error loading thumbnail">warning</Icon>
-      </Container>
-    );
-  }),
-  RT.withSuspense(({ size }) =>
-    <Container size={size}><CircularProgress /></Container>),
   ({ handle, size, alt = '', ...props }) => {
-    const src = use({ handle, size });
+    const api = useConfig().apiGatewayEndpoint;
+    const sign = AWS.Signer.useS3Signer();
+    const url = React.useMemo(() => sign(handle), [handle]);
+    const search = mkSearch({ url, size: sizeStr(size), output: 'raw' });
+    const src = `${api}/thumbnail${search}`;
     return <img src={src} alt={alt} {...props} />;
   });

--- a/catalog/app/components/Thumbnail/Thumbnail.js
+++ b/catalog/app/components/Thumbnail/Thumbnail.js
@@ -6,7 +6,6 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import Icon from '@material-ui/core/Icon';
 
 import * as AWS from 'utils/AWS';
-import { useCurrentBucketConfig } from 'utils/BucketConfig';
 import { useConfig } from 'utils/Config';
 import { withBoundary } from 'utils/ErrorBoundary';
 import { mkSearch } from 'utils/NamedRoutes';
@@ -35,9 +34,7 @@ const ThumbnailResource = Cache.createResource({
 });
 
 export const use = ({ handle, size }) => {
-  const cfg = useConfig();
-  const bucket = useCurrentBucketConfig() || {};
-  const api = bucket.apiGatewayEndpoint || cfg.apiGatewayEndpoint;
+  const api = useConfig().apiGatewayEndpoint;
   const sign = AWS.Signer.useS3Signer();
   return Cache.useData(ThumbnailResource, { api, sign, handle, size },
     { suspend: true });

--- a/catalog/app/components/Thumbnail/Thumbnail.js
+++ b/catalog/app/components/Thumbnail/Thumbnail.js
@@ -1,0 +1,85 @@
+import PT from 'prop-types';
+import * as React from 'react';
+import * as RC from 'recompose';
+import { unstable_Box as Box } from '@material-ui/core/Box';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Icon from '@material-ui/core/Icon';
+
+import * as AWS from 'utils/AWS';
+import { useCurrentBucketConfig } from 'utils/BucketConfig';
+import { useConfig } from 'utils/Config';
+import { withBoundary } from 'utils/ErrorBoundary';
+import { mkSearch } from 'utils/NamedRoutes';
+import * as Cache from 'utils/ResourceCache';
+import * as RT from 'utils/reactTools';
+
+
+const SIZES = {
+  sm: { w: 256, h: 256 },
+  lg: { w: 1024, h: 768 },
+};
+
+const sizeStr = (s) => `w${SIZES[s].w}h${SIZES[s].h}`;
+
+const ThumbnailResource = Cache.createResource({
+  name: 'Thumbnail',
+  fetch: async ({ api, sign, handle, size }) => {
+    const url = sign(handle);
+    const endpoint = `${api}/thumbnail${mkSearch({ url, size: sizeStr(size) })}`;
+    const r = await fetch(endpoint);
+    const json = await r.json();
+    const fmt = json.info.thumbnail_format.toLowerCase();
+    return `data:image/${fmt};base64, ${json.thumbnail}`;
+  },
+  key: ({ api, handle, size }) => ({ api, handle, size }),
+});
+
+export const use = ({ handle, size }) => {
+  const cfg = useConfig();
+  const bucket = useCurrentBucketConfig() || {};
+  const api = bucket.apiGatewayEndpoint || cfg.apiGatewayEndpoint;
+  const sign = AWS.Signer.useS3Signer();
+  return Cache.useData(ThumbnailResource, { api, sign, handle, size },
+    { suspend: true });
+};
+
+// eslint-disable-next-line react/prop-types
+const Container = ({ size, children }) => (
+  <Box
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    height={SIZES[size].h}
+    bgcolor="grey.100"
+    width={1}
+  >
+    {children}
+  </Box>
+);
+
+export default RT.composeComponent('Thumbnail',
+  RC.setPropTypes({
+    handle: PT.object.isRequired,
+    size: PT.oneOf(['sm', 'lg']),
+  }),
+  RC.defaultProps({
+    size: 'sm',
+  }),
+  withBoundary((props) => (error) => {
+    // eslint-disable-next-line no-console
+    console.warn('Error loading thumbnail', props);
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return (
+      // eslint-disable-next-line react/prop-types
+      <Container size={props.size}>
+        <Icon fontSize="large" title="Error loading thumbnail">warning</Icon>
+      </Container>
+    );
+  }),
+  RT.withSuspense(({ size }) =>
+    <Container size={size}><CircularProgress /></Container>),
+  ({ handle, size, alt = '', ...props }) => {
+    const src = use({ handle, size });
+    return <img src={src} alt={alt} {...props} />;
+  });

--- a/catalog/app/components/Thumbnail/index.js
+++ b/catalog/app/components/Thumbnail/index.js
@@ -1,0 +1,1 @@
+export { default } from './Thumbnail';

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -8,6 +8,9 @@ import { FormattedRelative } from 'react-intl';
 import { Link } from 'react-router-dom';
 import * as RC from 'recompose';
 import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Icon from '@material-ui/core/Icon';
 import IconButton from '@material-ui/core/IconButton';
@@ -197,6 +200,54 @@ const VersionInfo = RT.composeComponent('Bucket.File.VersionInfo',
     </React.Fragment>
   ));
 
+const Meta = RT.composeComponent('Bucket.File.Meta',
+  RC.setPropTypes({
+    bucket: PT.string.isRequired,
+    path: PT.string.isRequired,
+    version: PT.string,
+  }),
+  withStyles((t) => ({
+    root: {
+      marginBottom: t.spacing.unit * 2,
+    },
+    meta: {
+      fontFamily: t.typography.monospace.fontFamily,
+      fontSize: t.typography.body2.fontSize,
+      overflow: 'auto',
+      whiteSpace: 'pre',
+    },
+  })),
+  ({
+    classes,
+    bucket,
+    path,
+    version,
+  }) => {
+    const s3 = AWS.S3.use();
+    return (
+      <Data
+        fetch={requests.objectMeta}
+        params={{ s3, bucket, path, version }}
+      >
+        {R.pipe(
+          AsyncResult.case({
+            Ok: (meta) => !!meta && !R.isEmpty(meta) && (
+              <Card className={classes.root}>
+                <CardHeader title="Metadata" />
+                <CardContent>
+                  <div className={classes.meta}>
+                    {JSON.stringify(meta, null, 2)}
+                  </div>
+                </CardContent>
+              </Card>
+            ),
+            _: () => null,
+          }),
+        )}
+      </Data>
+    );
+  });
+
 export default RT.composeComponent('Bucket.File',
   withParsedQuery,
   withStyles(({ spacing: { unit }, palette }) => ({
@@ -255,6 +306,7 @@ export default RT.composeComponent('Bucket.File',
           </Button>
         ))}
       </div>
+      <Meta bucket={bucket} path={path} version={version} />
       <FilePreview handle={{ bucket, key: path, version }} />
     </React.Fragment>
   ));

--- a/catalog/app/containers/Bucket/FilePreview.js
+++ b/catalog/app/containers/Bucket/FilePreview.js
@@ -67,7 +67,7 @@ export default RT.composeComponent('Bucket.FilePreview',
                 Object is too large to preview in browser
               </Typography>
               {withSignedUrl(handle, (url) => (
-                <Button variant="outlined" href={url}>View raw</Button>
+                <Button variant="outlined" href={url}>View in Browser</Button>
               ))}
             </Message>
           ),
@@ -78,7 +78,7 @@ export default RT.composeComponent('Bucket.FilePreview',
                 Preview not available
               </Typography>
               {withSignedUrl(handle, (url) => (
-                <Button variant="outlined" href={url}>View raw</Button>
+                <Button variant="outlined" href={url}>View in Browser</Button>
               ))}
             </Message>
           ),

--- a/catalog/app/containers/Bucket/FilePreview.js
+++ b/catalog/app/containers/Bucket/FilePreview.js
@@ -87,6 +87,14 @@ export default RT.composeComponent('Bucket.FilePreview',
               <Typography variant="body1">Object does not exist</Typography>
             </Message>
           ),
+          // eslint-disable-next-line react/prop-types
+          MalformedJson: ({ originalError: { message } }) => (
+            <Message>
+              <Typography variant="body1" gutterBottom>
+                Malformed JSON: {message}
+              </Typography>
+            </Message>
+          ),
           Unexpected: (_, { fetch }) => (
             <Message>
               <Typography variant="body1" gutterBottom>

--- a/catalog/app/containers/Bucket/Summary.js
+++ b/catalog/app/containers/Bucket/Summary.js
@@ -125,7 +125,7 @@ const SummaryItemFile = composeComponent('Bucket.Summary.ItemFile',
                     Object is too large to preview in browser
                   </Typography>
                   {withSignedUrl(handle, (url) => (
-                    <Button variant="outlined" href={url}>View raw</Button>
+                    <Button variant="outlined" href={url}>View in Browser</Button>
                   ))}
                 </React.Fragment>
               ),
@@ -136,7 +136,7 @@ const SummaryItemFile = composeComponent('Bucket.Summary.ItemFile',
                     Preview not available
                   </Typography>
                   {withSignedUrl(handle, (url) => (
-                    <Button variant="outlined" href={url}>View raw</Button>
+                    <Button variant="outlined" href={url}>View in Browser</Button>
                   ))}
                 </React.Fragment>
               ),

--- a/catalog/app/containers/Bucket/Summary.js
+++ b/catalog/app/containers/Bucket/Summary.js
@@ -14,6 +14,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/styles';
 
 import * as Preview from 'components/Preview';
+import Thumbnail from 'components/Thumbnail';
 import * as AWS from 'utils/AWS';
 import AsyncResult from 'utils/AsyncResult';
 import Data from 'utils/Data';
@@ -185,7 +186,6 @@ const Thumbnails = composeComponent('Bucket.Summary.Thumbnails',
       display: 'block',
       marginLeft: 'auto',
       marginRight: 'auto',
-      maxHeight: 200,
       maxWidth: '100%',
     },
     filler: {
@@ -210,14 +210,12 @@ const Thumbnails = composeComponent('Bucket.Summary.Thumbnails',
                 to={urls.bucketFile(i.bucket, i.key, i.version)}
                 className={classes.link}
               >
-                {withSignedUrl(i, (url) => (
-                  <img
-                    className={classes.img}
-                    alt={basename(i.logicalKey || i.key)}
-                    title={basename(i.logicalKey || i.key)}
-                    src={url}
-                  />
-                ))}
+                <Thumbnail
+                  handle={i}
+                  className={classes.img}
+                  alt={basename(i.logicalKey || i.key)}
+                  title={basename(i.logicalKey || i.key)}
+                />
               </Link>
             ))}
             {R.times(

--- a/catalog/app/containers/Bucket/Summary.js
+++ b/catalog/app/containers/Bucket/Summary.js
@@ -142,6 +142,12 @@ const SummaryItemFile = composeComponent('Bucket.Summary.ItemFile',
               DoesNotExist: () => (
                 <Typography variant="body1">Object does not exist</Typography>
               ),
+              // eslint-disable-next-line react/prop-types
+              MalformedJson: ({ originalError: { message } }) => (
+                <Typography variant="body1" gutterBottom>
+                  Malformed JSON: {message}
+                </Typography>
+              ),
               Unexpected: (_, { fetch }) => (
                 <React.Fragment>
                   <Typography variant="body1" gutterBottom>

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -66,6 +66,14 @@ export const objectVersions = ({ s3, bucket, path }) =>
       })),
     ));
 
+export const objectMeta = ({ s3, bucket, path, version }) =>
+  s3.headObject({ Bucket: bucket, Key: path, VersionId: version })
+    .promise()
+    .then(R.pipe(
+      R.path(['Metadata', 'helium']),
+      JSON.parse,
+    ));
+
 const isValidManifest = R.both(Array.isArray, R.all(R.is(String)));
 
 export const summarize = async ({ s3, handle }) => {

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -5,6 +5,7 @@ import * as RT from 'utils/reactTools';
 import useMemoEq from 'utils/useMemoEq';
 
 import * as Config from './Config';
+import * as Credentials from './Credentials';
 
 
 const Ctx = React.createContext();
@@ -15,6 +16,7 @@ export const Provider = RT.composeComponent('AWS.S3.Provider',
 
 export const use = () => {
   const config = Config.use();
+  Credentials.use().suspend();
   const props = React.useContext(Ctx);
   // TODO: use cache?
   return useMemoEq({ ...config, ...props }, (cfg) => new S3(cfg));

--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -22,6 +22,7 @@ export const useRequestSigner = () => {
 };
 
 export const useS3Signer = ({ urlExpiration = DEFAULT_URL_EXPIRATION } = {}) => {
+  Credentials.use().suspend();
   const s3 = S3.use();
   return React.useCallback(
     ({ bucket, key, version }) =>

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -798,7 +798,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -3291,13 +3292,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -4194,6 +4197,11 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
       "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
+    },
+    "csv-parse": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.3.4.tgz",
+      "integrity": "sha512-M1R4WL+vt81+GnkKzi0s1qQM6WXvHQKDecNkpozzAEG8LHvIW9bq5eBnOKFQn50fTuAos7JodBh/07MK+J6G2Q=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -6847,7 +6855,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6868,12 +6877,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6888,17 +6899,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7015,7 +7029,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7027,6 +7042,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7041,6 +7057,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7048,12 +7065,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7072,6 +7091,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7152,7 +7172,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7164,6 +7185,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7249,7 +7271,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7285,6 +7308,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7304,6 +7328,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7347,12 +7372,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -261,6 +261,7 @@
     "compression": "^1.7.3",
     "connected-react-router": "^5.0.0",
     "cross-env": "^5.2.0",
+    "csv-parse": "^4.3.4",
     "dedent": "^0.7.0",
     "dompurify": "^1.0.10",
     "elasticsearch-browser": "^15.2.0",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -199,6 +199,7 @@
       "chalk",
       "compression",
       "cross-env",
+      "csv-parse",
       "dotenv",
       "express",
       "ip",


### PR DESCRIPTION
## Summary

- [x] preview VCF files
- [x] use preview endpoint for text formats
- [x] preview CSV/TSV
- [x] use thumbnailer for images
- [x] support compression (`.gz`, `.bz2`)
- [x] get and parse `Content-Range` header