### PR TITLE
Use QuiltTestCase in test_packages.py

### DIFF
--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -13,6 +13,9 @@ from t4 import Package
 from t4.util import (QuiltException, APP_NAME, APP_AUTHOR, BASE_DIR, BASE_PATH,
                      validate_package_name, parse_file_url)
 
+from ..utils import QuiltTestCase
+
+
 DATA_DIR = Path(__file__).parent / 'data'
 LOCAL_MANIFEST = DATA_DIR / 'local_manifest.jsonl'
 REMOTE_MANIFEST = DATA_DIR / 't4_manifest.jsonl'
@@ -34,938 +37,934 @@ def mock_make_api_call(self, operation_name, kwarg):
         return parsed_response
     raise NotImplementedError(operation_name)
 
-@patch('appdirs.user_data_dir', lambda x,y: os.path.join('test_appdir', x))
-def test_build():
-    """Verify that build dumps the manifest to appdirs directory."""
-    new_pkg = Package()
-
-    # Create a dummy file to add to the package.
-    test_file_name = 'bar'
-    with open(test_file_name, "w") as fd:
-        fd.write('test_file_content_string')
-        test_file = Path(fd.name)
-
-    # Build a new package into the local registry.
-    new_pkg = new_pkg.set('foo', test_file_name)
-    top_hash = new_pkg.build("Quilt/Test")
-
-    # Verify manifest is registered by hash.
-    out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
-    with open(out_path) as fd:
-        pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
-
-    # Verify latest points to the new location.
-    named_pointer_path = Path(BASE_PATH, ".quilt/named_packages/Quilt/Test/latest")
-    with open(named_pointer_path) as fd:
-        assert fd.read().replace('\n', '') == top_hash
-
-    # Test unnamed packages.
-    new_pkg = Package()
-    new_pkg = new_pkg.set('bar', test_file_name)
-    top_hash = new_pkg.build()
-    out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
-    with open(out_path) as fd:
-        pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
-
-@patch('appdirs.user_data_dir', lambda x,y: os.path.join('test_appdir', x))
-def test_default_registry():
-    new_pkg = Package()
-
-    # Create a dummy file to add to the package.
-    test_file_name = 'bar'
-    with open(test_file_name, "w") as fd:
-        fd.write('test_file_content_string')
-        test_file = Path(fd.name)
-
-    # Build a new package into the local registry.
-    new_pkg = new_pkg.set('foo', test_file_name)
-    top_hash = new_pkg.build("Quilt/Test")
-
-    # Verify manifest is registered by hash.
-    out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
-    with open(out_path) as fd:
-        pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
-
-    # Verify latest points to the new location.
-    named_pointer_path = Path(BASE_PATH, ".quilt/named_packages/Quilt/Test/latest")
-    with open(named_pointer_path) as fd:
-        assert fd.read().replace('\n', '') == top_hash
-
-    # Test unnamed packages.
-    new_pkg = Package()
-    new_pkg = new_pkg.set('bar', test_file_name)
-    top_hash = new_pkg.build()
-    out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
-    with open(out_path) as fd:
-        pkg = Package.load(fd)
-        assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
-
-    new_base_path = Path(BASE_PATH, ".quilttest")
-    with patch('t4.packages.get_from_config') as mock_config:
-        mock_config.return_value = new_base_path
-        top_hash = new_pkg.build("Quilt/Test")
-        out_path = Path(new_base_path, ".quilt/packages", top_hash).resolve()
-        with open(out_path) as fd:
-            pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
-
-    with patch('t4.packages.get_from_config') as mock_config:
-        mock_config.return_value = new_base_path
-        new_pkg.push("Quilt/Test")
-        with open(out_path) as fd:
-            pkg = Package.load(fd)
-            assert pkg['bar'].physical_keys[0].endswith('.quilttest/Quilt/Test/bar')
-
-@patch('appdirs.user_data_dir', lambda x,y: os.path.join('test_appdir', x))
-@patch('t4.Package.browse', lambda name, registry, top_hash: Package())
-def test_default_install_location():
-    """Verify that pushes to the default local install location work as expected"""
-    with patch('t4.Package.push') as push_mock:
-        Package.install('Quilt/nice-name', registry='s3://my-test-bucket')
-        push_mock.assert_called_once_with(
-            dest=t4.util.get_install_location(), 
-            name='Quilt/nice-name',
-            registry=ANY
-        )
-
-def test_read_manifest():
-    """ Verify reading serialized manifest from disk. """
-    with open(LOCAL_MANIFEST) as fd:
-        pkg = Package.load(fd)
-
-    out_path = 'new_manifest.jsonl'
-    with open(out_path, 'w') as fd:
-        pkg.dump(fd)
-
-    # Insepct the jsonl to verify everything is maintained, i.e.
-    # that load/dump results in an equivalent set.
-    # todo: Use load/dump once __eq__ implemented.
-    with open(LOCAL_MANIFEST) as fd:
-        original_set = list(jsonlines.Reader(fd))
-    with open(out_path) as fd:
-        written_set = list(jsonlines.Reader(fd))
-    assert len(original_set) == len(written_set)
-    assert sorted(original_set, key=lambda k: k.get('logical_key','manifest')) \
-        == sorted(written_set, key=lambda k: k.get('logical_key','manifest'))
 
 def no_op_mock(*args, **kwargs):
     pass
 
-def test_browse_package_from_registry():
-    """ Verify loading manifest locally and from s3 """
-    with patch('t4.Package._from_path') as pkgmock:
-        registry = BASE_PATH.as_uri()
-        pkg = Package()
-        pkgmock.return_value = pkg
-        top_hash = pkg.top_hash()
 
-        # local registry load
-        pkg = Package.browse(registry='local', top_hash=top_hash)
-        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-
-        pkgmock.reset_mock()
-
-        pkg = Package.browse('Quilt/nice-name', registry='local', top_hash=top_hash)
-        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-
-        pkgmock.reset_mock()
-
-        with patch('t4.packages.get_bytes') as dl_mock:
-            dl_mock.return_value = (top_hash.encode('utf-8'), None)
-            pkg = Package.browse('Quilt/nice-name', registry='local')
-            assert registry + '/.quilt/named_packages/Quilt/nice-name/latest' \
-                    == dl_mock.call_args_list[0][0][0]
-
-        assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-        pkgmock.reset_mock()
-
-        remote_registry = 's3://asdf/foo'
-        # remote load
-        pkg = Package.browse('Quilt/nice-name', registry=remote_registry, top_hash=top_hash)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-        pkgmock.reset_mock()
-        pkg = Package.browse(top_hash=top_hash, registry=remote_registry)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-
-        pkgmock.reset_mock()
-        with patch('t4.packages.get_bytes') as dl_mock:
-            dl_mock.return_value = (top_hash.encode('utf-8'), None)
-            pkg = Package.browse('Quilt/nice-name', registry=remote_registry)
-        assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
-                in [x[0][0] for x in pkgmock.call_args_list]
-
-        # default remote registry failure case
-        with patch('t4.packages.get_from_config', return_value=None):
-            with pytest.raises(QuiltException):
-                Package.browse('Quilt/nice-name')
-
-def test_local_install():
-    """Verify that installing from a local package works as expected."""
-    with patch('t4.packages.get_from_config') as get_config_mock, \
-        patch('t4.Package.push') as push_mock:
-        local_registry = '.'
-        get_config_mock.return_value = local_registry
-        pkg = Package()
-        pkg.build('Quilt/nice-name')
-
-        t4.Package.install('Quilt/nice-name', registry='local', dest='./')
-        push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=local_registry)
-
-def test_remote_install():
-    """Verify that installing from a local package works as expected."""
-    with patch('t4.packages.get_from_config') as get_config_mock, \
-        patch('t4.Package.push') as push_mock:
-        remote_registry = '.'
-        get_config_mock.return_value = remote_registry
-        pkg = Package()
-        pkg.build('Quilt/nice-name')
-
-        t4.Package.install('Quilt/nice-name', dest='./')
-        push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=remote_registry)
-
-def test_package_fetch():
-    """ Package.fetch() on nested, relative keys """
-    package_ = Package().set_dir('/', DATA_DIR / 'nested')
-
-    out_dir = 'output'
-    package_.fetch(out_dir)
-
-    expected = {'one.txt': '1', 'two.txt': '2', 'three.txt': '3'}
-    file_count = 0
-    for dirpath, _, files in os.walk(out_dir):
-        for name in files:
-            file_count += 1
-            with open(os.path.join(dirpath, name)) as file_:
-                assert name in expected, 'unexpected file: {}'.format(file_)
-                contents = file_.read().strip()
-                assert contents == expected[name], \
-                    'unexpected contents in {}: {}'.format(name, contents)
-    assert file_count == len(expected), \
-        'fetch wrote {} files; expected: {}'.format(file_count, expected)
-
-def test_fetch():
-    """ Verify fetching a package entry. """
-    pkg = (
-        Package()
-        .set('foo', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
-        .set('bar', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
-    )
-    pkg['foo'].meta['target'] = 'unicode'
-    pkg['bar'].meta['target'] = 'unicode'
-
-    with open(DATA_DIR / 'foo.txt') as fd:
-        assert fd.read().replace('\n', '') == '123'
-    # Copy foo.text to bar.txt
-    pkg['foo'].fetch('data/bar.txt')
-    with open('data/bar.txt') as fd:
-        assert fd.read().replace('\n', '') == '123'
-
-    # Raise an error if you copy to yourself.
-    with pytest.raises(shutil.SameFileError):
-        pkg['foo'].fetch(DATA_DIR / 'foo.txt')
-
-def test_load_into_t4():
-    """ Verify loading local manifest and data into S3. """
-    with patch('t4.packages.put_bytes') as bytes_mock, \
-         patch('t4.data_transfer._upload_file') as file_mock, \
-         patch('t4.packages.get_from_config') as config_mock:
-        file_mock.return_value = 'foo.txt'
-        config_mock.return_value = 's3://my_test_bucket'
+class PackageTest(QuiltTestCase):
+    def test_build(self):
+        """Verify that build dumps the manifest to appdirs directory."""
         new_pkg = Package()
+
         # Create a dummy file to add to the package.
-        contents = 'blah'
-        test_file = Path('bar')
-        test_file.write_text(contents)
-        new_pkg = new_pkg.set('foo', test_file)
-        new_pkg.push('Quilt/package', 's3://my_test_bucket/')
+        test_file_name = 'bar'
+        with open(test_file_name, "w") as fd:
+            fd.write('test_file_content_string')
+            test_file = Path(fd.name)
 
-        # Manifest copied
-        top_hash = new_pkg.top_hash()
-        bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
-        bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
+        # Build a new package into the local registry.
+        new_pkg = new_pkg.set('foo', test_file_name)
+        top_hash = new_pkg.build("Quilt/Test")
 
-        # Data copied
-        file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), 'my_test_bucket', 'Quilt/package/foo', {})
+        # Verify manifest is registered by hash.
+        out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
+        with open(out_path) as fd:
+            pkg = Package.load(fd)
+            assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
 
-def test_local_push():
-    """ Verify loading local manifest and data into S3. """
-    with patch('t4.packages.put_bytes') as bytes_mock, \
-         patch('t4.data_transfer._copy_local_file') as file_mock, \
-         patch('t4.packages.get_from_config') as config_mock:
-        file_mock.return_value = 'foo.txt'
-        config_mock.return_value = 'package_contents'
+        # Verify latest points to the new location.
+        named_pointer_path = Path(BASE_PATH, ".quilt/named_packages/Quilt/Test/latest")
+        with open(named_pointer_path) as fd:
+            assert fd.read().replace('\n', '') == top_hash
+
+        # Test unnamed packages.
         new_pkg = Package()
-        contents = 'blah'
-        test_file = Path('bar')
-        test_file.write_text(contents)
-        new_pkg = new_pkg.set('foo', test_file)
-        new_pkg.push('Quilt/package', 'package_contents')
+        new_pkg = new_pkg.set('bar', test_file_name)
+        top_hash = new_pkg.build()
+        out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
+        with open(out_path) as fd:
+            pkg = Package.load(fd)
+            assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
 
-        push_uri = Path('package_contents').resolve().as_uri()
+    def test_default_registry(self):
+        new_pkg = Package()
 
-        # Manifest copied
-        top_hash = new_pkg.top_hash()
-        bytes_mock.assert_any_call(top_hash.encode(), push_uri + '/.quilt/named_packages/Quilt/package/latest')
-        bytes_mock.assert_any_call(ANY, push_uri + '/.quilt/packages/' + top_hash)
+        # Create a dummy file to add to the package.
+        test_file_name = 'bar'
+        with open(test_file_name, "w") as fd:
+            fd.write('test_file_content_string')
+            test_file = Path(fd.name)
 
-        # Data copied
-        file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), str(Path('package_contents/Quilt/package/foo').resolve()), {})
+        # Build a new package into the local registry.
+        new_pkg = new_pkg.set('foo', test_file_name)
+        top_hash = new_pkg.build("Quilt/Test")
+
+        # Verify manifest is registered by hash.
+        out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
+        with open(out_path) as fd:
+            pkg = Package.load(fd)
+            assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
+
+        # Verify latest points to the new location.
+        named_pointer_path = Path(BASE_PATH, ".quilt/named_packages/Quilt/Test/latest")
+        with open(named_pointer_path) as fd:
+            assert fd.read().replace('\n', '') == top_hash
+
+        # Test unnamed packages.
+        new_pkg = Package()
+        new_pkg = new_pkg.set('bar', test_file_name)
+        top_hash = new_pkg.build()
+        out_path = Path(BASE_PATH, ".quilt/packages", top_hash)
+        with open(out_path) as fd:
+            pkg = Package.load(fd)
+            assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+
+        new_base_path = Path(BASE_PATH, ".quilttest")
+        with patch('t4.packages.get_from_config') as mock_config:
+            mock_config.return_value = new_base_path
+            top_hash = new_pkg.build("Quilt/Test")
+            out_path = Path(new_base_path, ".quilt/packages", top_hash).resolve()
+            with open(out_path) as fd:
+                pkg = Package.load(fd)
+                assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+
+        with patch('t4.packages.get_from_config') as mock_config:
+            mock_config.return_value = new_base_path
+            new_pkg.push("Quilt/Test")
+            with open(out_path) as fd:
+                pkg = Package.load(fd)
+                assert pkg['bar'].physical_keys[0].endswith('.quilttest/Quilt/Test/bar')
+
+    @patch('t4.Package.browse', lambda name, registry, top_hash: Package())
+    def test_default_install_location(self):
+        """Verify that pushes to the default local install location work as expected"""
+        with patch('t4.Package.push') as push_mock:
+            Package.install('Quilt/nice-name', registry='s3://my-test-bucket')
+            push_mock.assert_called_once_with(
+                dest=t4.util.get_install_location(),
+                name='Quilt/nice-name',
+                registry=ANY
+            )
+
+    def test_read_manifest(self):
+        """ Verify reading serialized manifest from disk. """
+        with open(LOCAL_MANIFEST) as fd:
+            pkg = Package.load(fd)
+
+        out_path = 'new_manifest.jsonl'
+        with open(out_path, 'w') as fd:
+            pkg.dump(fd)
+
+        # Insepct the jsonl to verify everything is maintained, i.e.
+        # that load/dump results in an equivalent set.
+        # todo: Use load/dump once __eq__ implemented.
+        with open(LOCAL_MANIFEST) as fd:
+            original_set = list(jsonlines.Reader(fd))
+        with open(out_path) as fd:
+            written_set = list(jsonlines.Reader(fd))
+        assert len(original_set) == len(written_set)
+        assert sorted(original_set, key=lambda k: k.get('logical_key','manifest')) \
+            == sorted(written_set, key=lambda k: k.get('logical_key','manifest'))
+
+    def test_browse_package_from_registry(self):
+        """ Verify loading manifest locally and from s3 """
+        with patch('t4.Package._from_path') as pkgmock:
+            registry = BASE_PATH.as_uri()
+            pkg = Package()
+            pkgmock.return_value = pkg
+            top_hash = pkg.top_hash()
+
+            # local registry load
+            pkg = Package.browse(registry='local', top_hash=top_hash)
+            assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+
+            pkgmock.reset_mock()
+
+            pkg = Package.browse('Quilt/nice-name', registry='local', top_hash=top_hash)
+            assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+
+            pkgmock.reset_mock()
+
+            with patch('t4.packages.get_bytes') as dl_mock:
+                dl_mock.return_value = (top_hash.encode('utf-8'), None)
+                pkg = Package.browse('Quilt/nice-name', registry='local')
+                assert registry + '/.quilt/named_packages/Quilt/nice-name/latest' \
+                        == dl_mock.call_args_list[0][0][0]
+
+            assert '{}/.quilt/packages/{}'.format(registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+            pkgmock.reset_mock()
+
+            remote_registry = 's3://asdf/foo'
+            # remote load
+            pkg = Package.browse('Quilt/nice-name', registry=remote_registry, top_hash=top_hash)
+            assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+            pkgmock.reset_mock()
+            pkg = Package.browse(top_hash=top_hash, registry=remote_registry)
+            assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+
+            pkgmock.reset_mock()
+            with patch('t4.packages.get_bytes') as dl_mock:
+                dl_mock.return_value = (top_hash.encode('utf-8'), None)
+                pkg = Package.browse('Quilt/nice-name', registry=remote_registry)
+            assert '{}/.quilt/packages/{}'.format(remote_registry, top_hash) \
+                    in [x[0][0] for x in pkgmock.call_args_list]
+
+            # default remote registry failure case
+            with patch('t4.packages.get_from_config', return_value=None):
+                with pytest.raises(QuiltException):
+                    Package.browse('Quilt/nice-name')
+
+    def test_local_install(self):
+        """Verify that installing from a local package works as expected."""
+        with patch('t4.packages.get_from_config') as get_config_mock, \
+            patch('t4.Package.push') as push_mock:
+            local_registry = '.'
+            get_config_mock.return_value = local_registry
+            pkg = Package()
+            pkg.build('Quilt/nice-name')
+
+            t4.Package.install('Quilt/nice-name', registry='local', dest='./')
+            push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=local_registry)
+
+    def test_remote_install(self):
+        """Verify that installing from a local package works as expected."""
+        with patch('t4.packages.get_from_config') as get_config_mock, \
+            patch('t4.Package.push') as push_mock:
+            remote_registry = '.'
+            get_config_mock.return_value = remote_registry
+            pkg = Package()
+            pkg.build('Quilt/nice-name')
+
+            t4.Package.install('Quilt/nice-name', dest='./')
+            push_mock.assert_called_once_with(dest='./', name='Quilt/nice-name', registry=remote_registry)
+
+    def test_package_fetch(self):
+        """ Package.fetch() on nested, relative keys """
+        package_ = Package().set_dir('/', DATA_DIR / 'nested')
+
+        out_dir = 'output'
+        package_.fetch(out_dir)
+
+        expected = {'one.txt': '1', 'two.txt': '2', 'three.txt': '3'}
+        file_count = 0
+        for dirpath, _, files in os.walk(out_dir):
+            for name in files:
+                file_count += 1
+                with open(os.path.join(dirpath, name)) as file_:
+                    assert name in expected, 'unexpected file: {}'.format(file_)
+                    contents = file_.read().strip()
+                    assert contents == expected[name], \
+                        'unexpected contents in {}: {}'.format(name, contents)
+        assert file_count == len(expected), \
+            'fetch wrote {} files; expected: {}'.format(file_count, expected)
+
+    def test_fetch(self):
+        """ Verify fetching a package entry. """
+        pkg = (
+            Package()
+            .set('foo', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
+            .set('bar', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
+        )
+        pkg['foo'].meta['target'] = 'unicode'
+        pkg['bar'].meta['target'] = 'unicode'
+
+        with open(DATA_DIR / 'foo.txt') as fd:
+            assert fd.read().replace('\n', '') == '123'
+        # Copy foo.text to bar.txt
+        pkg['foo'].fetch('data/bar.txt')
+        with open('data/bar.txt') as fd:
+            assert fd.read().replace('\n', '') == '123'
+
+        # Raise an error if you copy to yourself.
+        with pytest.raises(shutil.SameFileError):
+            pkg['foo'].fetch(DATA_DIR / 'foo.txt')
+
+    def test_load_into_t4(self):
+        """ Verify loading local manifest and data into S3. """
+        with patch('t4.packages.put_bytes') as bytes_mock, \
+            patch('t4.data_transfer._upload_file') as file_mock, \
+            patch('t4.packages.get_from_config') as config_mock:
+            file_mock.return_value = 'foo.txt'
+            config_mock.return_value = 's3://my_test_bucket'
+            new_pkg = Package()
+            # Create a dummy file to add to the package.
+            contents = 'blah'
+            test_file = Path('bar')
+            test_file.write_text(contents)
+            new_pkg = new_pkg.set('foo', test_file)
+            new_pkg.push('Quilt/package', 's3://my_test_bucket/')
+
+            # Manifest copied
+            top_hash = new_pkg.top_hash()
+            bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
+            bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
+
+            # Data copied
+            file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), 'my_test_bucket', 'Quilt/package/foo', {})
+
+    def test_local_push(self):
+        """ Verify loading local manifest and data into S3. """
+        with patch('t4.packages.put_bytes') as bytes_mock, \
+            patch('t4.data_transfer._copy_local_file') as file_mock, \
+            patch('t4.packages.get_from_config') as config_mock:
+            file_mock.return_value = 'foo.txt'
+            config_mock.return_value = 'package_contents'
+            new_pkg = Package()
+            contents = 'blah'
+            test_file = Path('bar')
+            test_file.write_text(contents)
+            new_pkg = new_pkg.set('foo', test_file)
+            new_pkg.push('Quilt/package', 'package_contents')
+
+            push_uri = Path('package_contents').resolve().as_uri()
+
+            # Manifest copied
+            top_hash = new_pkg.top_hash()
+            bytes_mock.assert_any_call(top_hash.encode(), push_uri + '/.quilt/named_packages/Quilt/package/latest')
+            bytes_mock.assert_any_call(ANY, push_uri + '/.quilt/packages/' + top_hash)
+
+            # Data copied
+            file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), str(Path('package_contents/Quilt/package/foo').resolve()), {})
 
 
-def test_package_deserialize():
-    """ Verify loading data from a local file. """
-    pkg = (
-        Package()
-        .set('foo', DATA_DIR / 'foo.txt', {'user_meta_foo': 'blah'})
-        .set('bar', DATA_DIR / 'foo.unrecognized.ext')
-        .set('baz', DATA_DIR / 'foo.txt')
-    )
-    pkg.build()
+    def test_package_deserialize(self):
+        """ Verify loading data from a local file. """
+        pkg = (
+            Package()
+            .set('foo', DATA_DIR / 'foo.txt', {'user_meta_foo': 'blah'})
+            .set('bar', DATA_DIR / 'foo.unrecognized.ext')
+            .set('baz', DATA_DIR / 'foo.txt')
+        )
+        pkg.build()
 
-    pkg['foo'].meta['target'] = 'unicode'
-    assert pkg['foo'].deserialize() == '123\n'
-    assert pkg['baz'].deserialize() == '123\n'
+        pkg['foo'].meta['target'] = 'unicode'
+        assert pkg['foo'].deserialize() == '123\n'
+        assert pkg['baz'].deserialize() == '123\n'
 
-    with pytest.raises(QuiltException):
-        pkg['bar'].deserialize()
+        with pytest.raises(QuiltException):
+            pkg['bar'].deserialize()
 
-def test_local_set_dir():
-    """ Verify building a package from a local directory. """
-    pkg = Package()
-
-    # Create some nested example files that contain their names.
-    foodir = pathlib.Path("foo_dir")
-    bazdir = pathlib.Path(foodir, "baz_dir")
-    bazdir.mkdir(parents=True, exist_ok=True)
-    with open('bar', 'w') as fd:
-        fd.write(fd.name)
-    with open('foo', 'w') as fd:
-        fd.write(fd.name)
-    with open(bazdir / 'baz', 'w') as fd:
-        fd.write(fd.name)
-    with open(foodir / 'bar', 'w') as fd:
-        fd.write(fd.name)
-
-    pkg = pkg.set_dir("/", ".", meta="test_meta")
-
-    assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
-    assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_keys[0]
-    assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_keys[0]
-    assert pkg.get_meta() == "test_meta"
-
-    pkg = Package()
-    pkg = pkg.set_dir('/','foo_dir/baz_dir/')
-    # todo nested at set_dir site or relative to set_dir path.
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_keys[0]
-
-    pkg = Package()
-    pkg = pkg.set_dir('my_keys', 'foo_dir/baz_dir/')
-    # todo nested at set_dir site or relative to set_dir path.
-    assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_keys[0]
-
-    # Verify ignoring files in the presence of a dot-quiltignore
-    with open('.quiltignore', 'w') as fd:
-        fd.write('foo\n')
-        fd.write('bar')
-
-    pkg = Package()
-    pkg = pkg.set_dir("/", ".")
-    assert 'foo_dir' in pkg.keys()
-    assert 'foo' not in pkg.keys() and 'bar' not in pkg.keys()
-
-    with open('.quiltignore', 'w') as fd:
-        fd.write('foo_dir')
-
-    pkg = Package()
-    pkg = pkg.set_dir("/", ".")
-    assert 'foo_dir' not in pkg.keys()
-
-    with open('.quiltignore', 'w') as fd:
-        fd.write('foo_dir\n')
-        fd.write('foo_dir/baz_dir')
-
-    pkg = Package()
-    pkg = pkg.set_dir("/", ".")
-    assert 'foo_dir/baz_dir' not in pkg.keys() and 'foo_dir' not in pkg.keys()
-
-    pkg = pkg.set_dir("new_dir", ".", meta="new_test_meta")
-
-    assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_keys[0]
-    assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_keys[0]
-    assert pkg['new_dir'].get_meta() == "new_test_meta"
-
-    # verify set_dir logical key shortcut
-    pkg = Package()
-    pkg.set_dir("/")
-    assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
-    assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
-
-
-def test_s3_set_dir():
-    """ Verify building a package from an S3 directory. """
-    with patch('t4.packages.list_object_versions') as list_object_versions_mock:
+    def test_local_set_dir(self):
+        """ Verify building a package from a local directory. """
         pkg = Package()
 
-        list_object_versions_mock.return_value = ([
-            dict(Key='foo/a.txt', VersionId='xyz', IsLatest=True),
-            dict(Key='foo/x/y.txt', VersionId='null', IsLatest=True),
-            dict(Key='foo/z.txt', VersionId='123', IsLatest=False),
-        ], [])
+        # Create some nested example files that contain their names.
+        foodir = pathlib.Path("foo_dir")
+        bazdir = pathlib.Path(foodir, "baz_dir")
+        bazdir.mkdir(parents=True, exist_ok=True)
+        with open('bar', 'w') as fd:
+            fd.write(fd.name)
+        with open('foo', 'w') as fd:
+            fd.write(fd.name)
+        with open(bazdir / 'baz', 'w') as fd:
+            fd.write(fd.name)
+        with open(foodir / 'bar', 'w') as fd:
+            fd.write(fd.name)
 
-        pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
+        pkg = pkg.set_dir("/", ".", meta="test_meta")
 
-        assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-        assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_keys[0]
+        assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_keys[0]
         assert pkg.get_meta() == "test_meta"
 
-        list_object_versions_mock.assert_called_with('bucket', 'foo/')
+        pkg = Package()
+        pkg = pkg.set_dir('/','foo_dir/baz_dir/')
+        # todo nested at set_dir site or relative to set_dir path.
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_keys[0]
 
-        list_object_versions_mock.reset_mock()
+        pkg = Package()
+        pkg = pkg.set_dir('my_keys', 'foo_dir/baz_dir/')
+        # todo nested at set_dir site or relative to set_dir path.
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_keys[0]
 
-        pkg.set_dir('bar', 's3://bucket/foo')
+        # Verify ignoring files in the presence of a dot-quiltignore
+        with open('.quiltignore', 'w') as fd:
+            fd.write('foo\n')
+            fd.write('bar')
 
-        assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-        assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+        pkg = Package()
+        pkg = pkg.set_dir("/", ".")
+        assert 'foo_dir' in pkg.keys()
+        assert 'foo' not in pkg.keys() and 'bar' not in pkg.keys()
 
-        list_object_versions_mock.assert_called_with('bucket', 'foo/')
+        with open('.quiltignore', 'w') as fd:
+            fd.write('foo_dir')
 
+        pkg = Package()
+        pkg = pkg.set_dir("/", ".")
+        assert 'foo_dir' not in pkg.keys()
 
-def test_package_entry_meta():
-    pkg = (
-        Package()
-        .set('foo', DATA_DIR / 'foo.txt', {'value': 'blah'})
-        .set('bar', DATA_DIR / 'foo.txt', {'value': 'blah2'})
-    )
-    pkg['foo'].meta['target'] = 'unicode'
-    pkg['bar'].meta['target'] = 'unicode'
+        with open('.quiltignore', 'w') as fd:
+            fd.write('foo_dir\n')
+            fd.write('foo_dir/baz_dir')
 
-    assert pkg['foo'].get_user_meta() == {'value': 'blah'}
-    assert pkg['bar'].get_user_meta() == {'value': 'blah2'}
+        pkg = Package()
+        pkg = pkg.set_dir("/", ".")
+        assert 'foo_dir/baz_dir' not in pkg.keys() and 'foo_dir' not in pkg.keys()
 
-    assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah'}}
-    assert pkg['bar'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah2'}}
+        pkg = pkg.set_dir("new_dir", ".", meta="new_test_meta")
 
-    pkg['foo'].set_user_meta({'value': 'other value'})
-    assert pkg['foo'].get_user_meta() == {'value': 'other value'}
-    assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'other value'}}
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_keys[0]
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_keys[0]
+        assert pkg['new_dir'].get_meta() == "new_test_meta"
 
-
-def test_list_local_packages():
-    """Verify that list returns packages in the appdirs directory."""
-    temp_local_registry = Path('test_registry').resolve().as_uri()
-    with patch('t4.packages.get_package_registry', lambda path: temp_local_registry), \
-         patch('t4.api.get_package_registry', lambda path: temp_local_registry):
-        # Build a new package into the local registry.
-        Package().build("Quilt/Foo")
-        Package().build("Quilt/Bar")
-        Package().build("Quilt/Test")
-
-        # Verify packages are returned.
-        pkgs = t4.list_packages()
-        assert len(pkgs) == 3
-        assert "Quilt/Foo" in pkgs
-        assert "Quilt/Bar" in pkgs
-
-        # Verify package repr is as expected.
-        pkgs_repr = str(pkgs)
-        assert 'Quilt/Test:latest' in pkgs_repr
-        assert 'Quilt/Foo:latest' in pkgs_repr
-        assert 'Quilt/Bar:latest' in pkgs_repr
-
-        # Test unnamed packages are not added.
-        Package().build()
-        pkgs = t4.list_packages()
-        assert len(pkgs) == 3
-
-        # Verify manifest is registered by hash when local path given
-        pkgs = t4.list_packages("/")
-        assert "Quilt/Foo" in pkgs
-        assert "Quilt/Bar" in pkgs
-
-def test_set_package_entry():
-    """ Set the physical key for a PackageEntry"""
-    pkg = (
-        Package()
-        .set('foo', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
-        .set('bar', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
-    )
-    pkg['foo'].meta['target'] = 'unicode'
-    pkg['bar'].meta['target'] = 'unicode'
-
-    # Build a dummy file to add to the map.
-    with open('bar.txt', "w") as fd:
-        fd.write('test_file_content_string')
-        test_file = Path(fd.name)
-    pkg['bar'].set('bar.txt')
-
-    assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
-
-    # Test shortcut codepath
-    pkg = Package().set('bar.txt')
-    assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_keys[0]
-
-def test_tophash_changes():
-    test_file = Path('test.txt')
-    test_file.write_text('asdf', 'utf-8')
-
-    pkg = Package()
-    th1 = pkg.top_hash()
-    pkg.set('asdf', test_file)
-    pkg.build()
-    th2 = pkg.top_hash()
-    assert th1 != th2
-
-    test_file.write_text('jkl', 'utf-8')
-    pkg.set('jkl', test_file)
-    pkg.build()
-    th3 = pkg.top_hash()
-    assert th1 != th3
-    assert th2 != th3
-
-    pkg.delete('jkl')
-    th4 = pkg.top_hash()
-    assert th2 == th4
-
-def test_keys():
-    pkg = Package()
-    assert not pkg.keys()
-
-    pkg.set('asdf', LOCAL_MANIFEST)
-    assert set(pkg.keys()) == {'asdf'}
-
-    pkg.set('jkl;', REMOTE_MANIFEST)
-    assert set(pkg.keys()) == {'asdf', 'jkl;'}
-
-    pkg.delete('asdf')
-    assert set(pkg.keys()) == {'jkl;'}
+        # verify set_dir logical key shortcut
+        pkg = Package()
+        pkg.set_dir("/")
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
 
 
-def test_iter():
-    pkg = Package()
-    assert not pkg
+    def test_s3_set_dir(self):
+        """ Verify building a package from an S3 directory. """
+        with patch('t4.packages.list_object_versions') as list_object_versions_mock:
+            pkg = Package()
 
-    pkg.set('asdf', LOCAL_MANIFEST)
-    assert list(pkg) == ['asdf']
+            list_object_versions_mock.return_value = ([
+                dict(Key='foo/a.txt', VersionId='xyz', IsLatest=True),
+                dict(Key='foo/x/y.txt', VersionId='null', IsLatest=True),
+                dict(Key='foo/z.txt', VersionId='123', IsLatest=False),
+            ], [])
 
-    pkg.set('jkl;', REMOTE_MANIFEST)
-    assert set(pkg) == {'asdf', 'jkl;'}
+            pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
 
-def test_invalid_set_key():
-    """Verify an exception when setting a key with a path object."""
-    pkg = Package()
-    with pytest.raises(TypeError):
-        pkg.set('asdf/jkl', 123)
+            assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+            assert pkg.get_meta() == "test_meta"
 
-def test_brackets():
-    pkg = Package()
-    pkg.set('asdf/jkl', LOCAL_MANIFEST)
-    pkg.set('asdf/qwer', LOCAL_MANIFEST)
-    pkg.set('qwer/asdf', LOCAL_MANIFEST)
-    assert set(pkg.keys()) == {'asdf', 'qwer'}
+            list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
-    pkg2 = pkg['asdf']
-    assert set(pkg2.keys()) == {'jkl', 'qwer'}
+            list_object_versions_mock.reset_mock()
 
-    assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri()
+            pkg.set_dir('bar', 's3://bucket/foo')
 
-    assert pkg['asdf']['qwer'] == pkg['asdf/qwer'] == pkg[('asdf', 'qwer')]
-    assert pkg[[]] == pkg
+            assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
 
-    pkg = (
-        Package()
-        .set('foo', DATA_DIR / 'foo.txt', {'foo': 'blah'})
-    )
-    pkg['foo'].meta['target'] = 'unicode'
+            list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
-    pkg.build()
 
-    assert pkg['foo'].deserialize() == '123\n'
-    assert pkg['foo']() == '123\n'
+    def test_package_entry_meta(self):
+        pkg = (
+            Package()
+            .set('foo', DATA_DIR / 'foo.txt', {'value': 'blah'})
+            .set('bar', DATA_DIR / 'foo.txt', {'value': 'blah2'})
+        )
+        pkg['foo'].meta['target'] = 'unicode'
+        pkg['bar'].meta['target'] = 'unicode'
 
-    with pytest.raises(KeyError):
-        pkg['baz']
+        assert pkg['foo'].get_user_meta() == {'value': 'blah'}
+        assert pkg['bar'].get_user_meta() == {'value': 'blah2'}
 
-    with pytest.raises(TypeError):
-        pkg[b'asdf']
+        assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah'}}
+        assert pkg['bar'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah2'}}
 
-    with pytest.raises(TypeError):
-        pkg[0]
+        pkg['foo'].set_user_meta({'value': 'other value'})
+        assert pkg['foo'].get_user_meta() == {'value': 'other value'}
+        assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'other value'}}
 
-def test_list_remote_packages():
-    # with patch('t4.api.list_objects',
-    #            return_value=([{'Prefix': 'foo'},{'Prefix': 'bar'}],[])) as mock:
-    def pseudo_list_objects(bucket, prefix, recursive):
-        if prefix == '.quilt/named_packages/':
-            return ([{'Prefix': '.quilt/named_packages/foo/'}], [])
-        elif prefix == '.quilt/named_packages/foo/':
-            return ([{'Prefix': '.quilt/named_packages/foo/bar/'}], [])
-        elif prefix == '.quilt/named_packages/foo/bar/':
-            import datetime
-            return (
-                [], [
-                    {'Key': '.quilt/named_packages/foo/bar/1549931634',
-                     'LastModified': datetime.datetime.now()},
-                    {'Key': '.quilt/named_packages/foo/bar/latest',
-                     'LastModified': datetime.datetime.now()}]
+
+    def test_list_local_packages(self):
+        """Verify that list returns packages in the appdirs directory."""
+        temp_local_registry = Path('test_registry').resolve().as_uri()
+        with patch('t4.packages.get_package_registry', lambda path: temp_local_registry), \
+            patch('t4.api.get_package_registry', lambda path: temp_local_registry):
+            # Build a new package into the local registry.
+            Package().build("Quilt/Foo")
+            Package().build("Quilt/Bar")
+            Package().build("Quilt/Test")
+
+            # Verify packages are returned.
+            pkgs = t4.list_packages()
+            assert len(pkgs) == 3
+            assert "Quilt/Foo" in pkgs
+            assert "Quilt/Bar" in pkgs
+
+            # Verify package repr is as expected.
+            pkgs_repr = str(pkgs)
+            assert 'Quilt/Test:latest' in pkgs_repr
+            assert 'Quilt/Foo:latest' in pkgs_repr
+            assert 'Quilt/Bar:latest' in pkgs_repr
+
+            # Test unnamed packages are not added.
+            Package().build()
+            pkgs = t4.list_packages()
+            assert len(pkgs) == 3
+
+            # Verify manifest is registered by hash when local path given
+            pkgs = t4.list_packages("/")
+            assert "Quilt/Foo" in pkgs
+            assert "Quilt/Bar" in pkgs
+
+    def test_set_package_entry(self):
+        """ Set the physical key for a PackageEntry"""
+        pkg = (
+            Package()
+            .set('foo', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
+            .set('bar', DATA_DIR / 'foo.txt', {'user_meta': 'blah'})
+        )
+        pkg['foo'].meta['target'] = 'unicode'
+        pkg['bar'].meta['target'] = 'unicode'
+
+        # Build a dummy file to add to the map.
+        with open('bar.txt', "w") as fd:
+            fd.write('test_file_content_string')
+            test_file = Path(fd.name)
+        pkg['bar'].set('bar.txt')
+
+        assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+
+        # Test shortcut codepath
+        pkg = Package().set('bar.txt')
+        assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_keys[0]
+
+    def test_tophash_changes(self):
+        test_file = Path('test.txt')
+        test_file.write_text('asdf', 'utf-8')
+
+        pkg = Package()
+        th1 = pkg.top_hash()
+        pkg.set('asdf', test_file)
+        pkg.build()
+        th2 = pkg.top_hash()
+        assert th1 != th2
+
+        test_file.write_text('jkl', 'utf-8')
+        pkg.set('jkl', test_file)
+        pkg.build()
+        th3 = pkg.top_hash()
+        assert th1 != th3
+        assert th2 != th3
+
+        pkg.delete('jkl')
+        th4 = pkg.top_hash()
+        assert th2 == th4
+
+    def test_keys(self):
+        pkg = Package()
+        assert not pkg.keys()
+
+        pkg.set('asdf', LOCAL_MANIFEST)
+        assert set(pkg.keys()) == {'asdf'}
+
+        pkg.set('jkl;', REMOTE_MANIFEST)
+        assert set(pkg.keys()) == {'asdf', 'jkl;'}
+
+        pkg.delete('asdf')
+        assert set(pkg.keys()) == {'jkl;'}
+
+
+    def test_iter(self):
+        pkg = Package()
+        assert not pkg
+
+        pkg.set('asdf', LOCAL_MANIFEST)
+        assert list(pkg) == ['asdf']
+
+        pkg.set('jkl;', REMOTE_MANIFEST)
+        assert set(pkg) == {'asdf', 'jkl;'}
+
+    def test_invalid_set_key(self):
+        """Verify an exception when setting a key with a path object."""
+        pkg = Package()
+        with pytest.raises(TypeError):
+            pkg.set('asdf/jkl', 123)
+
+    def test_brackets(self):
+        pkg = Package()
+        pkg.set('asdf/jkl', LOCAL_MANIFEST)
+        pkg.set('asdf/qwer', LOCAL_MANIFEST)
+        pkg.set('qwer/asdf', LOCAL_MANIFEST)
+        assert set(pkg.keys()) == {'asdf', 'qwer'}
+
+        pkg2 = pkg['asdf']
+        assert set(pkg2.keys()) == {'jkl', 'qwer'}
+
+        assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri()
+
+        assert pkg['asdf']['qwer'] == pkg['asdf/qwer'] == pkg[('asdf', 'qwer')]
+        assert pkg[[]] == pkg
+
+        pkg = (
+            Package()
+            .set('foo', DATA_DIR / 'foo.txt', {'foo': 'blah'})
+        )
+        pkg['foo'].meta['target'] = 'unicode'
+
+        pkg.build()
+
+        assert pkg['foo'].deserialize() == '123\n'
+        assert pkg['foo']() == '123\n'
+
+        with pytest.raises(KeyError):
+            pkg['baz']
+
+        with pytest.raises(TypeError):
+            pkg[b'asdf']
+
+        with pytest.raises(TypeError):
+            pkg[0]
+
+    def test_list_remote_packages(self):
+        # with patch('t4.api.list_objects',
+        #            return_value=([{'Prefix': 'foo'},{'Prefix': 'bar'}],[])) as mock:
+        def pseudo_list_objects(bucket, prefix, recursive):
+            if prefix == '.quilt/named_packages/':
+                return ([{'Prefix': '.quilt/named_packages/foo/'}], [])
+            elif prefix == '.quilt/named_packages/foo/':
+                return ([{'Prefix': '.quilt/named_packages/foo/bar/'}], [])
+            elif prefix == '.quilt/named_packages/foo/bar/':
+                import datetime
+                return (
+                    [], [
+                        {'Key': '.quilt/named_packages/foo/bar/1549931634',
+                        'LastModified': datetime.datetime.now()},
+                        {'Key': '.quilt/named_packages/foo/bar/latest',
+                        'LastModified': datetime.datetime.now()}]
+                )
+            else:
+                raise ValueError
+
+        with patch('t4.api.list_objects', side_effect=pseudo_list_objects), \
+            patch('t4.api.get_bytes', return_value=(b'100', None)), \
+            patch('t4.Package.browse', return_value=Package()):
+            pkgs = t4.list_packages('s3://my_test_bucket/')
+
+            assert len(pkgs) == 1
+            assert list(pkgs) == ['foo/bar']
+
+            expected = (
+                'PACKAGE                    \tTOPHASH     \tCREATED     \tSIZE        \t\n'
+                'foo/bar:latest             \t100            \tnow            \t0 Bytes\t\n'
             )
-        else:
-            raise ValueError
-
-    with patch('t4.api.list_objects', side_effect=pseudo_list_objects), \
-        patch('t4.api.get_bytes', return_value=(b'100', None)), \
-        patch('t4.Package.browse', return_value=Package()):
-        pkgs = t4.list_packages('s3://my_test_bucket/')
-
-        assert len(pkgs) == 1
-        assert list(pkgs) == ['foo/bar']
-
-        expected = (
-            'PACKAGE                    \tTOPHASH     \tCREATED     \tSIZE        \t\n'
-            'foo/bar:latest             \t100            \tnow            \t0 Bytes\t\n'
-        )
-        assert str(pkgs) == expected
+            assert str(pkgs) == expected
 
 
-def test_validate_package_name():
-    validate_package_name("a/b")
-    validate_package_name("21312/bes")
-    with pytest.raises(QuiltException):
-        validate_package_name("b")
-    with pytest.raises(QuiltException):
-        validate_package_name("a/b/")
-    with pytest.raises(QuiltException):
-        validate_package_name("a\\/b")
-    with pytest.raises(QuiltException):
-        validate_package_name("a/b/c")
-    with pytest.raises(QuiltException):
-        validate_package_name("a/")
-    with pytest.raises(QuiltException):
-        validate_package_name("/b")
-    with pytest.raises(QuiltException):
-        validate_package_name("b")
+    def test_validate_package_name(self):
+        validate_package_name("a/b")
+        validate_package_name("21312/bes")
+        with pytest.raises(QuiltException):
+            validate_package_name("b")
+        with pytest.raises(QuiltException):
+            validate_package_name("a/b/")
+        with pytest.raises(QuiltException):
+            validate_package_name("a\\/b")
+        with pytest.raises(QuiltException):
+            validate_package_name("a/b/c")
+        with pytest.raises(QuiltException):
+            validate_package_name("a/")
+        with pytest.raises(QuiltException):
+            validate_package_name("/b")
+        with pytest.raises(QuiltException):
+            validate_package_name("b")
 
-def test_diff():
-    new_pkg = Package()
+    def test_diff(self):
+        new_pkg = Package()
 
-    # Create a dummy file to add to the package.
-    test_file_name = 'bar'
-    with open(test_file_name, "w") as fd:
-        fd.write('test_file_content_string')
-        test_file = Path(fd.name)
+        # Create a dummy file to add to the package.
+        test_file_name = 'bar'
+        with open(test_file_name, "w") as fd:
+            fd.write('test_file_content_string')
+            test_file = Path(fd.name)
 
-    # Build a new package into the local registry.
-    new_pkg = new_pkg.set('foo', test_file_name)
-    top_hash = new_pkg.build("Quilt/Test")
+        # Build a new package into the local registry.
+        new_pkg = new_pkg.set('foo', test_file_name)
+        top_hash = new_pkg.build("Quilt/Test")
 
-    p1 = Package.browse('Quilt/Test', registry='local')
-    p2 = Package.browse('Quilt/Test', registry='local')
-    assert p1.diff(p2) == ([], [], [])
-
-
-def test_dir_meta():
-    test_meta = {'test': 'meta'}
-    pkg = Package()
-    pkg.set('asdf/jkl', LOCAL_MANIFEST)
-    pkg.set('asdf/qwer', LOCAL_MANIFEST)
-    pkg.set('qwer/asdf', LOCAL_MANIFEST)
-    pkg.set('qwer/as/df', LOCAL_MANIFEST)
-    pkg.build()
-    assert pkg['asdf'].get_meta() == {}
-    assert pkg.get_meta() == {}
-    assert pkg['qwer']['as'].get_meta() == {}
-    pkg['asdf'].set_meta(test_meta)
-    assert pkg['asdf'].get_meta() == test_meta
-    pkg['qwer']['as'].set_meta(test_meta)
-    assert pkg['qwer']['as'].get_meta() == test_meta
-    pkg.set_meta(test_meta)
-    assert pkg.get_meta() == test_meta
-    dump_path = 'test_meta'
-    with open(dump_path, 'w') as f:
-        pkg.dump(f)
-    with open(dump_path) as f:
-        pkg2 = Package.load(f)
-    assert pkg2['asdf'].get_meta() == test_meta
-    assert pkg2['qwer']['as'].get_meta() == test_meta
-    assert pkg2.get_meta() == test_meta
-
-def test_top_hash_stable():
-    """Ensure that top_hash() never changes for a given manifest"""
-
-    registry = DATA_DIR
-    top_hash = '20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733'
-
-    pkg = Package.browse(registry=registry, top_hash=top_hash)
-
-    assert pkg.top_hash() == top_hash, \
-           "Unexpected top_hash for {}/.quilt/packages/{}".format(registry, top_hash)
+        p1 = Package.browse('Quilt/Test', registry='local')
+        p2 = Package.browse('Quilt/Test', registry='local')
+        assert p1.diff(p2) == ([], [], [])
 
 
-@patch('appdirs.user_data_dir', lambda x, y: os.path.join('test_appdir', x))
-def test_local_package_delete():
-    """Verify local package delete works."""
-    top_hash = Package().build("Quilt/Test")
-    t4.delete_package('Quilt/Test', registry=BASE_PATH)
-
-    assert 'Quilt/Test' not in t4.list_packages()
-    assert top_hash not in [p.name for p in
-                            Path(BASE_PATH, '.quilt/packages').iterdir()]
-
-
-@patch('appdirs.user_data_dir', lambda x, y: os.path.join('test_appdir', x))
-def test_local_package_delete_overlapping():
-    """
-    Verify local package delete works when multiple packages reference the
-    same tophash.
-    """
-    top_hash = Package().build("Quilt/Test1")
-    top_hash = Package().build("Quilt/Test2")
-    t4.delete_package('Quilt/Test1', registry=BASE_PATH)
-
-    assert 'Quilt/Test1' not in t4.list_packages()
-    assert top_hash in [p.name for p in
-                        Path(BASE_PATH, '.quilt/packages').iterdir()]
-
-    t4.delete_package('Quilt/Test2', registry=BASE_PATH)
-    assert 'Quilt/Test2' not in t4.list_packages()
-    assert top_hash not in [p.name for p in
-                            Path(BASE_PATH, '.quilt/packages').iterdir()]
-
-
-@patch('t4.data_transfer.s3_client')
-def test_remote_package_delete(s3_client):
-    """Verify remote package delete works."""
-    def list_packages_mock(*args, **kwargs): return ['Quilt/Test']
-
-    def _tophashes_with_packages_mock(*args, **kwargs): return {'101': {'Quilt/Test'}}
-
-    def list_objects_mock(*args): return [
-        {'Key': '.quilt/named_packages/Quilt/Test/0'},
-        {'Key': '.quilt/named_packages/Quilt/Test/latest'}
-    ]
-
-    def get_bytes_mock(*args): return b'101', None
-
-    with patch('t4.api.list_packages', new=list_packages_mock), \
-            patch('t4.api._tophashes_with_packages', new=_tophashes_with_packages_mock), \
-            patch('t4.api.list_objects', new=list_objects_mock), \
-            patch('t4.api.get_bytes', new=get_bytes_mock), \
-            patch('t4.api.delete_object') as delete_mock:
-        t4.delete_package('Quilt/Test', registry='s3://test-bucket')
-
-        delete_mock.assert_any_call('test-bucket', '.quilt/packages/101')
-        delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test/0')
-        delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test/latest')
-
-
-@patch('t4.data_transfer.s3_client')
-def test_remote_package_delete_overlapping(s3_client):
-    """
-    Verify remote package delete works when multiple packages reference the
-    same tophash.
-    """
-    def list_packages_mock(*args, **kwargs): return ['Quilt/Test1', 'Quilt/Test2']
-
-    def _tophashes_with_packages_mock(*args, **kwargs): return {'101': {'Quilt/Test1', 'Quilt/Test2'}}
-
-    def list_objects_mock(*args): return [
-        {'Key': '.quilt/named_packages/Quilt/Test1/0'},
-        {'Key': '.quilt/named_packages/Quilt/Test1/latest'},
-        {'Key': '.quilt/named_packages/Quilt/Test2/0'},
-        {'Key': '.quilt/named_packages/Quilt/Test2/latest'}
-    ]
-
-    def get_bytes_mock(*args): return b'101', None
-
-    with patch('t4.api.list_packages', new=list_packages_mock), \
-            patch('t4.api._tophashes_with_packages', new=_tophashes_with_packages_mock), \
-            patch('t4.api.list_objects', new=list_objects_mock), \
-            patch('t4.api.get_bytes', new=get_bytes_mock), \
-            patch('t4.api.delete_object') as delete_mock:
-        t4.delete_package('Quilt/Test1', registry='s3://test-bucket')
-
-        # the reference count for the tophash 101 is still one, so it should still exist
-        assert call('test-bucket', '.quilt/packages/101') not in delete_mock.call_args_list
-        delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test1/0')
-        delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test1/latest')
-
-
-def test_commit_message_on_push():
-    """ Verify commit messages populate correctly on push."""
-    with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
-        with open(REMOTE_MANIFEST) as fd:
-            pkg = Package.load(fd)
-        with patch('t4.data_transfer._download_file', return_value='foo.txt'), \
-                patch('t4.Package.build', new=no_op_mock), \
-                patch('t4.packages.get_from_config') as config_mock:
-            config_mock.return_value = BASE_DIR
-            pkg.push('Quilt/test_pkg_name', 'pkg', message='test_message')
-            assert pkg._meta['message'] == 'test_message'
-
-            # ensure messages are strings
-            with pytest.raises(ValueError):
-                pkg.push('Quilt/test_pkg_name', 'pkg', message={})
-
-def test_overwrite_dir_fails():
-    with pytest.raises(QuiltException):
+    def test_dir_meta(self):
+        test_meta = {'test': 'meta'}
         pkg = Package()
         pkg.set('asdf/jkl', LOCAL_MANIFEST)
-        pkg.set('asdf', LOCAL_MANIFEST)
+        pkg.set('asdf/qwer', LOCAL_MANIFEST)
+        pkg.set('qwer/asdf', LOCAL_MANIFEST)
+        pkg.set('qwer/as/df', LOCAL_MANIFEST)
+        pkg.build()
+        assert pkg['asdf'].get_meta() == {}
+        assert pkg.get_meta() == {}
+        assert pkg['qwer']['as'].get_meta() == {}
+        pkg['asdf'].set_meta(test_meta)
+        assert pkg['asdf'].get_meta() == test_meta
+        pkg['qwer']['as'].set_meta(test_meta)
+        assert pkg['qwer']['as'].get_meta() == test_meta
+        pkg.set_meta(test_meta)
+        assert pkg.get_meta() == test_meta
+        dump_path = 'test_meta'
+        with open(dump_path, 'w') as f:
+            pkg.dump(f)
+        with open(dump_path) as f:
+            pkg2 = Package.load(f)
+        assert pkg2['asdf'].get_meta() == test_meta
+        assert pkg2['qwer']['as'].get_meta() == test_meta
+        assert pkg2.get_meta() == test_meta
 
-def test_overwrite_entry_fails():
-    with pytest.raises(QuiltException):
+    def test_top_hash_stable(self):
+        """Ensure that top_hash() never changes for a given manifest"""
+
+        registry = DATA_DIR
+        top_hash = '20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733'
+
+        pkg = Package.browse(registry=registry, top_hash=top_hash)
+
+        assert pkg.top_hash() == top_hash, \
+            "Unexpected top_hash for {}/.quilt/packages/{}".format(registry, top_hash)
+
+
+    def test_local_package_delete(self):
+        """Verify local package delete works."""
+        top_hash = Package().build("Quilt/Test")
+        t4.delete_package('Quilt/Test', registry=BASE_PATH)
+
+        assert 'Quilt/Test' not in t4.list_packages()
+        assert top_hash not in [p.name for p in
+                                Path(BASE_PATH, '.quilt/packages').iterdir()]
+
+
+    def test_local_package_delete_overlapping(self):
+        """
+        Verify local package delete works when multiple packages reference the
+        same tophash.
+        """
+        top_hash = Package().build("Quilt/Test1")
+        top_hash = Package().build("Quilt/Test2")
+        t4.delete_package('Quilt/Test1', registry=BASE_PATH)
+
+        assert 'Quilt/Test1' not in t4.list_packages()
+        assert top_hash in [p.name for p in
+                            Path(BASE_PATH, '.quilt/packages').iterdir()]
+
+        t4.delete_package('Quilt/Test2', registry=BASE_PATH)
+        assert 'Quilt/Test2' not in t4.list_packages()
+        assert top_hash not in [p.name for p in
+                                Path(BASE_PATH, '.quilt/packages').iterdir()]
+
+
+    def test_remote_package_delete(self):
+        """Verify remote package delete works."""
+        def list_packages_mock(*args, **kwargs): return ['Quilt/Test']
+
+        def _tophashes_with_packages_mock(*args, **kwargs): return {'101': {'Quilt/Test'}}
+
+        def list_objects_mock(*args): return [
+            {'Key': '.quilt/named_packages/Quilt/Test/0'},
+            {'Key': '.quilt/named_packages/Quilt/Test/latest'}
+        ]
+
+        def get_bytes_mock(*args): return b'101', None
+
+        with patch('t4.api.list_packages', new=list_packages_mock), \
+                patch('t4.api._tophashes_with_packages', new=_tophashes_with_packages_mock), \
+                patch('t4.api.list_objects', new=list_objects_mock), \
+                patch('t4.api.get_bytes', new=get_bytes_mock), \
+                patch('t4.api.delete_object') as delete_mock:
+            t4.delete_package('Quilt/Test', registry='s3://test-bucket')
+
+            delete_mock.assert_any_call('test-bucket', '.quilt/packages/101')
+            delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test/0')
+            delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test/latest')
+
+
+    def test_remote_package_delete_overlapping(self):
+        """
+        Verify remote package delete works when multiple packages reference the
+        same tophash.
+        """
+        def list_packages_mock(*args, **kwargs): return ['Quilt/Test1', 'Quilt/Test2']
+
+        def _tophashes_with_packages_mock(*args, **kwargs): return {'101': {'Quilt/Test1', 'Quilt/Test2'}}
+
+        def list_objects_mock(*args): return [
+            {'Key': '.quilt/named_packages/Quilt/Test1/0'},
+            {'Key': '.quilt/named_packages/Quilt/Test1/latest'},
+            {'Key': '.quilt/named_packages/Quilt/Test2/0'},
+            {'Key': '.quilt/named_packages/Quilt/Test2/latest'}
+        ]
+
+        def get_bytes_mock(*args): return b'101', None
+
+        with patch('t4.api.list_packages', new=list_packages_mock), \
+                patch('t4.api._tophashes_with_packages', new=_tophashes_with_packages_mock), \
+                patch('t4.api.list_objects', new=list_objects_mock), \
+                patch('t4.api.get_bytes', new=get_bytes_mock), \
+                patch('t4.api.delete_object') as delete_mock:
+            t4.delete_package('Quilt/Test1', registry='s3://test-bucket')
+
+            # the reference count for the tophash 101 is still one, so it should still exist
+            assert call('test-bucket', '.quilt/packages/101') not in delete_mock.call_args_list
+            delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test1/0')
+            delete_mock.assert_any_call('test-bucket', '.quilt/named_packages/Quilt/Test1/latest')
+
+
+    def test_commit_message_on_push(self):
+        """ Verify commit messages populate correctly on push."""
+        with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+            with open(REMOTE_MANIFEST) as fd:
+                pkg = Package.load(fd)
+            with patch('t4.data_transfer._download_file', return_value='foo.txt'), \
+                    patch('t4.Package.build', new=no_op_mock), \
+                    patch('t4.packages.get_from_config') as config_mock:
+                config_mock.return_value = BASE_DIR
+                pkg.push('Quilt/test_pkg_name', 'pkg', message='test_message')
+                assert pkg._meta['message'] == 'test_message'
+
+                # ensure messages are strings
+                with pytest.raises(ValueError):
+                    pkg.push('Quilt/test_pkg_name', 'pkg', message={})
+
+    def test_overwrite_dir_fails(self):
+        with pytest.raises(QuiltException):
+            pkg = Package()
+            pkg.set('asdf/jkl', LOCAL_MANIFEST)
+            pkg.set('asdf', LOCAL_MANIFEST)
+
+    def test_overwrite_entry_fails(self):
+        with pytest.raises(QuiltException):
+            pkg = Package()
+            pkg.set('asdf', LOCAL_MANIFEST)
+            pkg.set('asdf/jkl', LOCAL_MANIFEST)
+
+    def test_siblings_succeed(self):
         pkg = Package()
-        pkg.set('asdf', LOCAL_MANIFEST)
-        pkg.set('asdf/jkl', LOCAL_MANIFEST)
+        pkg.set('as/df', LOCAL_MANIFEST)
+        pkg.set('as/qw', LOCAL_MANIFEST)
 
-def test_siblings_succeed():
-    pkg = Package()
-    pkg.set('as/df', LOCAL_MANIFEST)
-    pkg.set('as/qw', LOCAL_MANIFEST)
-
-def test_local_repr():
-    TEST_REPR = (
-        "(local Package)\n"
-        " └─asdf\n"
-        " └─path1/\n"
-        "   └─asdf\n"
-        "   └─qwer\n"
-        " └─path2/\n"
-        "   └─first/\n"
-        "     └─asdf\n"
-        "   └─second/\n"
-        "     └─asdf\n"
-        " └─qwer\n"
-    )
-    pkg = Package()
-    pkg.set('asdf', LOCAL_MANIFEST)
-    pkg.set('qwer', LOCAL_MANIFEST)
-    pkg.set('path1/asdf', LOCAL_MANIFEST)
-    pkg.set('path1/qwer', LOCAL_MANIFEST)
-    pkg.set('path2/first/asdf', LOCAL_MANIFEST)
-    pkg.set('path2/second/asdf', LOCAL_MANIFEST)
-    assert repr(pkg) == TEST_REPR
-
-def test_remote_repr():
-    with patch('t4.packages.get_size_and_meta', return_value=(0, dict(), '0')):
+    def test_local_repr(self):
         TEST_REPR = (
-            "(remote Package)\n"
+            "(local Package)\n"
             " └─asdf\n"
-        )
-        pkg = Package()
-        pkg.set('asdf', 's3://my-bucket/asdf')
-        assert repr(pkg) == TEST_REPR
-
-        TEST_REPR = (
-            "(remote Package)\n"
-            " └─asdf\n"
+            " └─path1/\n"
+            "   └─asdf\n"
+            "   └─qwer\n"
+            " └─path2/\n"
+            "   └─first/\n"
+            "     └─asdf\n"
+            "   └─second/\n"
+            "     └─asdf\n"
             " └─qwer\n"
         )
         pkg = Package()
-        pkg.set('asdf', 's3://my-bucket/asdf')
+        pkg.set('asdf', LOCAL_MANIFEST)
         pkg.set('qwer', LOCAL_MANIFEST)
+        pkg.set('path1/asdf', LOCAL_MANIFEST)
+        pkg.set('path1/qwer', LOCAL_MANIFEST)
+        pkg.set('path2/first/asdf', LOCAL_MANIFEST)
+        pkg.set('path2/second/asdf', LOCAL_MANIFEST)
         assert repr(pkg) == TEST_REPR
 
-def test_repr_empty_package():
-    pkg = Package()
-    r = repr(pkg)
-    assert r == "(empty Package)"
+    def test_remote_repr(self):
+        with patch('t4.packages.get_size_and_meta', return_value=(0, dict(), '0')):
+            TEST_REPR = (
+                "(remote Package)\n"
+                " └─asdf\n"
+            )
+            pkg = Package()
+            pkg.set('asdf', 's3://my-bucket/asdf')
+            assert repr(pkg) == TEST_REPR
 
-def test_manifest():
-    pkg = Package()
-    pkg.set('as/df', LOCAL_MANIFEST)
-    pkg.set('as/qw', LOCAL_MANIFEST)
-    top_hash = pkg.build()
-    manifest = list(pkg.manifest)
+            TEST_REPR = (
+                "(remote Package)\n"
+                " └─asdf\n"
+                " └─qwer\n"
+            )
+            pkg = Package()
+            pkg.set('asdf', 's3://my-bucket/asdf')
+            pkg.set('qwer', LOCAL_MANIFEST)
+            assert repr(pkg) == TEST_REPR
 
-    pkg2 = Package.browse(top_hash=top_hash, registry='local')
-    assert list(pkg.manifest) == list(pkg2.manifest)
+    def test_repr_empty_package(self):
+        pkg = Package()
+        r = repr(pkg)
+        assert r == "(empty Package)"
 
+    def test_manifest(self):
+        pkg = Package()
+        pkg.set('as/df', LOCAL_MANIFEST)
+        pkg.set('as/qw', LOCAL_MANIFEST)
+        top_hash = pkg.build()
+        manifest = list(pkg.manifest)
 
-def test_map():
-    pkg = Package()
-    pkg.set('as/df', LOCAL_MANIFEST)
-    pkg.set('as/qw', LOCAL_MANIFEST)
-    assert set(pkg.map(lambda lk, entry: lk)) == {'as/df', 'as/qw'}
-
-    pkg['as'].set_meta({'foo': 'bar'})
-    assert set(pkg.map(lambda lk, entry: lk, include_directories=True)) ==\
-           {'as/df', 'as/qw', 'as/'}
-
-
-def test_filter():
-    pkg = Package()
-    pkg.set('a/df', LOCAL_MANIFEST)
-    pkg.set('a/qw', LOCAL_MANIFEST)
-
-    p_copy = pkg.filter(lambda lk, entry: lk == 'a/df')
-    assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
-
-    pkg = Package()
-    pkg.set('a/df', LOCAL_MANIFEST)
-    pkg.set('a/qw', LOCAL_MANIFEST)
-    pkg.set('b/df', LOCAL_MANIFEST)
-    pkg['a'].set_meta({'foo': 'bar'})
-    pkg['b'].set_meta({'foo': 'bar'})
-
-    p_copy = pkg.filter(lambda lk, entry: lk == 'a/', include_directories=True)
-    assert list(p_copy) == []
-
-    p_copy = pkg.filter(lambda lk, entry: lk == 'a/' or lk == 'a/df',
-                        include_directories=True)
-    assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
+        pkg2 = Package.browse(top_hash=top_hash, registry='local')
+        assert list(pkg.manifest) == list(pkg2.manifest)
 
 
-def test_reduce():
-    pkg = Package()
-    pkg.set('as/df', LOCAL_MANIFEST)
-    pkg.set('as/qw', LOCAL_MANIFEST)
-    assert pkg.reduce(lambda a, b: a) == ('as/df', pkg['as/df'])
-    assert pkg.reduce(lambda a, b: b) == ('as/qw', pkg['as/qw'])
-    assert list(pkg.reduce(lambda a, b: a + [b], [])) == [
-        ('as/df', pkg['as/df']),
-        ('as/qw', pkg['as/qw'])
-    ]
+    def test_map(self):
+        pkg = Package()
+        pkg.set('as/df', LOCAL_MANIFEST)
+        pkg.set('as/qw', LOCAL_MANIFEST)
+        assert set(pkg.map(lambda lk, entry: lk)) == {'as/df', 'as/qw'}
 
-    pkg['as'].set_meta({'foo': 'bar'})
-    assert pkg.reduce(lambda a, b: b, include_directories=True) ==\
-           ('as/qw', pkg['as/qw'])
-    assert list(pkg.reduce(lambda a, b: a + [b], [], include_directories=True)) == [
-        ('as/', pkg['as']),
-        ('as/df', pkg['as/df']),
-        ('as/qw', pkg['as/qw'])
-    ]
+        pkg['as'].set_meta({'foo': 'bar'})
+        assert set(pkg.map(lambda lk, entry: lk, include_directories=True)) ==\
+            {'as/df', 'as/qw', 'as/'}
 
 
-def test_import():
-    with patch('t4.Package.browse') as browse_mock, \
-        patch('t4.imports.list_packages') as list_packages_mock:
-        browse_mock.return_value = t4.Package()
-        list_packages_mock.return_value = ['foo/bar', 'foo/baz']
+    def test_filter(self):
+        pkg = Package()
+        pkg.set('a/df', LOCAL_MANIFEST)
+        pkg.set('a/qw', LOCAL_MANIFEST)
 
-        from t4.data.foo import bar
-        assert isinstance(bar, Package)
-        browse_mock.assert_has_calls([call('foo/baz'), call('foo/bar')], any_order=True)
+        p_copy = pkg.filter(lambda lk, entry: lk == 'a/df')
+        assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
 
-        from t4.data import foo
-        assert hasattr(foo, 'bar') and hasattr(foo, 'baz')
+        pkg = Package()
+        pkg.set('a/df', LOCAL_MANIFEST)
+        pkg.set('a/qw', LOCAL_MANIFEST)
+        pkg.set('b/df', LOCAL_MANIFEST)
+        pkg['a'].set_meta({'foo': 'bar'})
+        pkg['b'].set_meta({'foo': 'bar'})
+
+        p_copy = pkg.filter(lambda lk, entry: lk == 'a/', include_directories=True)
+        assert list(p_copy) == []
+
+        p_copy = pkg.filter(lambda lk, entry: lk == 'a/' or lk == 'a/df',
+                            include_directories=True)
+        assert list(p_copy) == ['a'] and list(p_copy['a']) == ['df']
 
 
-def test_invalid_key():
-    pkg = Package()
-    with pytest.raises(QuiltException):
-        pkg.set('', LOCAL_MANIFEST)
-    with pytest.raises(QuiltException):
-        pkg.set('foo/', LOCAL_MANIFEST)
-    with pytest.raises(QuiltException):
-        pkg.set('foo', './')
-    with pytest.raises(QuiltException):
-        pkg.set('foo', os.path.dirname(__file__))
+    def test_reduce(self):
+        pkg = Package()
+        pkg.set('as/df', LOCAL_MANIFEST)
+        pkg.set('as/qw', LOCAL_MANIFEST)
+        assert pkg.reduce(lambda a, b: a) == ('as/df', pkg['as/df'])
+        assert pkg.reduce(lambda a, b: b) == ('as/qw', pkg['as/qw'])
+        assert list(pkg.reduce(lambda a, b: a + [b], [])) == [
+            ('as/df', pkg['as/df']),
+            ('as/qw', pkg['as/qw'])
+        ]
+
+        pkg['as'].set_meta({'foo': 'bar'})
+        assert pkg.reduce(lambda a, b: b, include_directories=True) ==\
+            ('as/qw', pkg['as/qw'])
+        assert list(pkg.reduce(lambda a, b: a + [b], [], include_directories=True)) == [
+            ('as/', pkg['as']),
+            ('as/df', pkg['as/df']),
+            ('as/qw', pkg['as/qw'])
+        ]
+
+
+    def test_import(self):
+        with patch('t4.Package.browse') as browse_mock, \
+            patch('t4.imports.list_packages') as list_packages_mock:
+            browse_mock.return_value = t4.Package()
+            list_packages_mock.return_value = ['foo/bar', 'foo/baz']
+
+            from t4.data.foo import bar
+            assert isinstance(bar, Package)
+            browse_mock.assert_has_calls([call('foo/baz'), call('foo/bar')], any_order=True)
+
+            from t4.data import foo
+            assert hasattr(foo, 'bar') and hasattr(foo, 'baz')
+
+
+    def test_invalid_key(self):
+        pkg = Package()
+        with pytest.raises(QuiltException):
+            pkg.set('', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo/', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo', './')
+        with pytest.raises(QuiltException):
+            pkg.set('foo', os.path.dirname(__file__))


### PR DESCRIPTION
Mostly indentation changes. Also:
- Stop patching user_data_dir: it didn't do anything cause it was too late. But conftest.py already takes care of that.
- Stop patching s3_client; not needed, and already taken care of by QuiltTestCase.