### PR TITLE
Global rename of HeliumConfig to T4Config

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -423,15 +423,10 @@ def _create_es():
 
     return es
 
-def search(query, bucket=None):
+def search(query):
     """
     Searches your bucket. query can contain plaintext, and can also contain clauses
     like $key:"$value" that search for exact matches on specific keys.
-
-    Args:
-        query: an elastic search query
-        bucket(None): federated bucket to search.  If `None`, the default
-            bucket for your catalog is used.
 
     Returns either the request object (in case of an error) or a list of objects with the following keys:
         key: key of the object

--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -15,7 +15,7 @@ from .data_transfer import (copy_file, get_bytes, put_bytes, delete_object, list
 from .formats import FormatRegistry
 from .packages import get_package_registry, Package
 from .session import get_registry_url, get_session
-from .util import (HeliumConfig, QuiltException, CONFIG_PATH,
+from .util import (T4Config, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, fix_url, parse_file_url, parse_s3_url, read_yaml, validate_url,
                    write_yaml, yaml_has_comments, validate_package_name)
 
@@ -423,10 +423,15 @@ def _create_es():
 
     return es
 
-def search(query):
+def search(query, bucket=None):
     """
     Searches your bucket. query can contain plaintext, and can also contain clauses
     like $key:"$value" that search for exact matches on specific keys.
+
+    Args:
+        query: an elastic search query
+        bucket(None): federated bucket to search.  If `None`, the default
+            bucket for your catalog is used.
 
     Returns either the request object (in case of an error) or a list of objects with the following keys:
         key: key of the object
@@ -536,15 +541,14 @@ def config(*autoconfig_url, **config_values):
         >>> t4.config(navigator_url='http://example.com',
         ...           elastic_search_url='http://example.com/queries')
 
-    When setting config values, unrecognized values are rejected.  Acceptable
-    config values can be found in `t4.util.CONFIG_TEMPLATE`.
+    Default config values can be found in `t4.util.CONFIG_TEMPLATE`.
 
     Args:
         autoconfig_url: A (single) URL indicating a location to configure from
         **config_values: `key=value` pairs to set in the config
 
     Returns:
-        HeliumConfig: (an ordered Mapping)
+        T4Config: (an ordered Mapping)
     """
     if autoconfig_url and config_values:
         raise QuiltException("Expected either an auto-config URL or key=value pairs, but got both.")
@@ -584,13 +588,13 @@ def config(*autoconfig_url, **config_values):
             for key in set(config_template) - set(new_config):
                 new_config[key] = config_template[key]
             write_yaml(new_config, CONFIG_PATH, keep_backup=True)
-            return HeliumConfig(CONFIG_PATH, new_config)
+            return T4Config(CONFIG_PATH, new_config)
         # Use our config + their configured values, keeping our comments.
         else:
             for key, value in new_config.items():
                 config_template[key] = value
             write_yaml(config_template, CONFIG_PATH, keep_backup=True)
-            return HeliumConfig(CONFIG_PATH, config_template)
+            return T4Config(CONFIG_PATH, config_template)
     # No autoconfig URL given -- use local config
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
@@ -607,4 +611,4 @@ def config(*autoconfig_url, **config_values):
             local_config[key] = value
         write_yaml(local_config, CONFIG_PATH, keep_backup=True)
 
-    return HeliumConfig(CONFIG_PATH, local_config)
+    return T4Config(CONFIG_PATH, local_config)

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -235,10 +235,10 @@ def validate_url(url):
 # user's usage in an interpreted environment like Jupyter, and keeping the displayed
 # information concise.  Given the limitations of the other options, making a class with
 # custom repr panned out to be the best (and shortest) option.
-class HeliumConfig(OrderedDict):
+class T4Config(OrderedDict):
     def __init__(self, filepath, *args, **kwargs):
         self.filepath = pathlib.Path(filepath)
-        super(HeliumConfig, self).__init__(*args, **kwargs)
+        super(T4Config, self).__init__(*args, **kwargs)
 
     def __repr__(self):
         return "<{} at {!r} {}>".format(type(self).__name__, str(self.filepath), json.dumps(self, indent=4))

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -35,7 +35,7 @@ __Arguments__
 
 __Returns__
 
-`HeliumConfig`: (an ordered Mapping)
+`T4Config`: (an ordered Mapping)
 
 
 ## copy(src, dest)  {#copy}


### PR DESCRIPTION
## Description
Outdated "Helium" reference.  This just renames `HeliumConfig` to `T4Config` globally, and removes an outdated docstring statement.

