### PR TITLE
Determine and set object size at set_dir time

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -600,7 +600,8 @@ class Package(object):
                 if not obj['IsLatest']:
                     continue
                 obj_url = make_s3_url(src_bucket, obj['Key'], obj.get('VersionId'))
-                entry = PackageEntry([obj_url], None, None, None)
+                size, _, _ = get_size_and_meta(obj_url)
+                entry = PackageEntry([obj_url], size, None, None)
                 logical_key = obj['Key'][len(src_key):]
                 # TODO: Warn if overwritting a logical key?
                 root.set(logical_key, entry)

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -600,8 +600,7 @@ class Package(object):
                 if not obj['IsLatest']:
                     continue
                 obj_url = make_s3_url(src_bucket, obj['Key'], obj.get('VersionId'))
-                size, _, _ = get_size_and_meta(obj_url)
-                entry = PackageEntry([obj_url], size, None, None)
+                entry = PackageEntry([obj_url], obj['Size'], None, None)
                 logical_key = obj['Key'][len(src_key):]
                 # TODO: Warn if overwritting a logical key?
                 root.set(logical_key, entry)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -435,9 +435,9 @@ class PackageTest(QuiltTestCase):
             pkg = Package()
 
             list_object_versions_mock.return_value = ([
-                dict(Key='foo/a.txt', VersionId='xyz', IsLatest=True),
-                dict(Key='foo/x/y.txt', VersionId='null', IsLatest=True),
-                dict(Key='foo/z.txt', VersionId='123', IsLatest=False),
+                dict(Key='foo/a.txt', VersionId='xyz', IsLatest=True, Size=10),
+                dict(Key='foo/x/y.txt', VersionId='null', IsLatest=True, Size=10),
+                dict(Key='foo/z.txt', VersionId='123', IsLatest=False, Size=10),
             ], [])
 
             pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
@@ -445,6 +445,7 @@ class PackageTest(QuiltTestCase):
             assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
             assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
             assert pkg.get_meta() == "test_meta"
+            assert pkg['x']['y.txt'].size is not None  # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
@@ -454,6 +455,7 @@ class PackageTest(QuiltTestCase):
 
             assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
             assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+            assert pkg['bar']['a.txt'].size is not None  # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -445,7 +445,7 @@ class PackageTest(QuiltTestCase):
             assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
             assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
             assert pkg.get_meta() == "test_meta"
-            assert pkg['x']['y.txt'].size is not None  # GH368
+            assert pkg['x']['y.txt'].size == 10  # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
 
@@ -455,7 +455,7 @@ class PackageTest(QuiltTestCase):
 
             assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
             assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
-            assert pkg['bar']['a.txt'].size is not None  # GH368
+            assert pkg['bar']['a.txt'].size == 10 # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
 


### PR DESCRIPTION
The current `set_dir` doesn't work as expected when given a remote path because it doesn't remember to check and set object size, which is inconsistent with the behavior of `set`, which does. This is behavior that `push` now relies on, so we need to do this here, too.

In the future we should move the size check to a dedicated step in `push` and/or `build`.