### PR TITLE
Fix import logic

### DIFF
--- a/api/python/t4/imports.py
+++ b/api/python/t4/imports.py
@@ -3,7 +3,7 @@
 from importlib.machinery import ModuleSpec
 import sys
 
-from t4.util import BASE_PATH
+from t4.util import get_from_config
 from t4 import list_packages, Package
 
 
@@ -29,6 +29,7 @@ class DataPackageImporter:
         Module executor.
         """
         name_parts = module.__name__.split('.')
+        registry = get_from_config('default_local_registry')
 
         if module.__name__ == 't4.data':
             # __path__ must be set even if the package is virtual. Since __path__ will be
@@ -44,7 +45,7 @@ class DataPackageImporter:
             for pkg in list_packages():
                 pkg_user, pkg_name = pkg.split('/')
                 if pkg_user == namespace:
-                    module.__dict__[pkg_name] = Package.browse(pkg)
+                    module.__dict__[pkg_name] = Package.browse(pkg, registry=registry)
 
             module.__path__ = MODULE_PATH
             return module


### PR DESCRIPTION
The current `import.py` implementation used a behavior of `t4.Package.browse` which implicitly depended on the method relying on `default_local_registry` for its registry source when no `registry` argument is provided

 However, we changed that behavior in a relatively recent PR: `t4.Package.browse` now relies on `default_remote_registry` instead.

This behavior change broke imports. The tests didn't pick this up because the tests mock out `t4.Package.browse` out. This PR fixes this bug and makes the expected behavior from `t4.Package.browse` explicit (which should prevent any similar bugs in the future).