### PR TITLE
Catalog: CSV preview: skip lines w/ errors

### DIFF
--- a/catalog/app/components/Preview/loaders/Csv.js
+++ b/catalog/app/components/Preview/loaders/Csv.js
@@ -13,6 +13,7 @@ export const detect = R.pipe(utils.stripCompression,
 export const load = utils.previewFetcher('txt', ({ info: { data } }, { handle }) => {
   const opts = {
     delimiter: utils.stripCompression(handle.key).endsWith('tsv') ? '\t' : ',',
+    skip_lines_with_error: true,
   };
   const head = parse(data.head.join('\n'), opts);
   const tail = data.tail.length ? parse(data.tail.join('\n'), opts) : [];

--- a/catalog/app/components/Preview/renderers/Table.js
+++ b/catalog/app/components/Preview/renderers/Table.js
@@ -9,8 +9,11 @@ import { makeStyles } from '@material-ui/styles';
 
 const useStyles = makeStyles((t) => ({
   root: {
-    overflow: 'auto',
     padding: t.spacing.unit * 1.5,
+    width: '100%',
+  },
+  wrapper: {
+    overflow: 'auto',
   },
   row: {
     height: t.spacing.unit * 3,
@@ -21,6 +24,7 @@ const useStyles = makeStyles((t) => ({
   },
   cell: {
     border: 'none',
+    whiteSpace: 'nowrap',
 
     '&, &:last-child': {
       paddingLeft: t.spacing.unit,
@@ -38,42 +42,44 @@ const Table = ({ head, tail, className, ...props }) => {
 
   return (
     <div className={cx(className, classes.root)} {...props}>
-      <MuiTable>
-        <TableBody>
-          {head.map((row, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <TableRow key={`head:${i}`} className={classes.row}>
-              {row.map((col, j) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <TableCell key={`head:${i}:${j}`} className={classes.cell}>
-                  {col}
+      <div className={classes.wrapper}>
+        <MuiTable>
+          <TableBody>
+            {head.map((row, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <TableRow key={`head:${i}`} className={classes.row}>
+                {row.map((col, j) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <TableCell key={`head:${i}:${j}`} className={classes.cell}>
+                    {col}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+            {!!tail.length && (
+              <TableRow key="skip" className={classes.row}>
+                <TableCell
+                  colSpan={head[0].length}
+                  className={cx(classes.cell, classes.skip)}
+                >
+                  &hellip; rows skipped &hellip;
                 </TableCell>
-              ))}
-            </TableRow>
-          ))}
-          {!!tail.length && (
-            <TableRow key="skip" className={classes.row}>
-              <TableCell
-                colSpan={head[0].length}
-                className={cx(classes.cell, classes.skip)}
-              >
-                &hellip; rows skipped &hellip;
-              </TableCell>
-            </TableRow>
-          )}
-          {tail.map((row, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <TableRow key={`tail:${i}`} className={classes.row}>
-              {row.map((col, j) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <TableCell key={`tail:${i}:${j}`} className={classes.cell}>
-                  {col}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
-      </MuiTable>
+              </TableRow>
+            )}
+            {tail.map((row, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <TableRow key={`tail:${i}`} className={classes.row}>
+                {row.map((col, j) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <TableCell key={`tail:${i}:${j}`} className={classes.cell}>
+                    {col}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </MuiTable>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
I've stumbled upon a strange preview endpoint behaviour: [see the link](http://localhost:3000/b/quilt-aics/tree/aics/label-free-imaging-collection/data_feats.csv).
The last line of the head is clipped, so the csv parser was throwing an exception, but there was no indication that the contents are clipped, and the tail was empty. I've configured parser to skip the lines with errors -- it works, but there's no indication that the line(s) are skipped, so it may mislead the user. I'd suggest handling this stuff on the backend: either returning the whole line or skipping some and putting the rest into the tail, so there's clear indication that the lines were skipped.

cc @akarve 

PS: most of the changes in this PR are styling tweaks for table display, not _directly_ related