### PR TITLE
Use top hash with space for consistency

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -250,7 +250,7 @@ def list_packages(registry=None):
                 pkg_name_display_width = 27
 
             out = (f"{self._fmt_str('PACKAGE', pkg_name_display_width)}\t"
-                   f"{self._fmt_str('TOPHASH', 12)}\t"
+                   f"{self._fmt_str('TOP HASH', 12)}\t"
                    f"{self._fmt_str('CREATED', 12)}\t"
                    f"{self._fmt_str('SIZE', 12)}\t"
                    f"\n")

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -659,7 +659,7 @@ class PackageTest(QuiltTestCase):
             assert list(pkgs) == ['foo/bar']
 
             expected = (
-                'PACKAGE                    \tTOPHASH     \tCREATED     \tSIZE        \t\n'
+                'PACKAGE                    \tTOP HASH    \tCREATED     \tSIZE        \t\n'
                 'foo/bar:latest             \t100            \tnow            \t0 Bytes\t\n'
                 'foo/bar                    \t90             \t30 seconds ago \t0 Bytes\t\n'
             )


### PR DESCRIPTION
We use `top hash` (with a space) throughout the rest of the API and documentation. This tiny PR adds a space to the lettering in `list_packages` as well, for consistency.