### PR TITLE
Support "local" keyword argument in list_packages

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -266,7 +266,11 @@ def list_packages(registry=None):
                         f"{self._fmt_str(size_str, 15).rstrip(' ')}\t\n")
             return out
 
-    base_registry = get_package_registry(fix_url(registry) if registry else None)
+    if registry is None or registry == 'local':
+        base_registry = get_package_registry(None)
+    else:
+        base_registry = get_package_registry(fix_url(registry))
+
     named_packages = base_registry + '/named_packages'
 
     pkg_info = []

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -496,6 +496,9 @@ class PackageTest(QuiltTestCase):
             assert "Quilt/Foo" in pkgs
             assert "Quilt/Bar" in pkgs
 
+            # Verify 'local' keyword works as expected.
+            assert list(pkgs) == list(t4.list_packages('local'))
+
             # Verify package repr is as expected.
             pkgs_repr = str(pkgs)
             assert 'Quilt/Test:latest' in pkgs_repr


### PR DESCRIPTION
`build` and `install` already support a special `local` argument. For consistency, we should have `list_packages` accept this argument as well.