### PR TITLE
Downgrade target not supporting xattrs from error to warning

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -187,7 +187,14 @@ def _download_file(callback, src_bucket, src_key, src_version, dest_path, overri
             fd.write(chunk)
             callback(len(chunk))
 
-    xattr.setxattr(dest_path, HELIUM_XATTR, json.dumps(meta).encode('utf-8'))
+    try:
+        xattr.setxattr(dest_path, HELIUM_XATTR, json.dumps(meta).encode('utf-8'))
+    except OSError:
+        # this indicates that the destination path is on an OS that doesn't support xattrs
+        # if this is the case, raise a warning and leave xattrs blank
+        warnings.warn(
+            f'Could not write file xattrs for destination {dest_path}.'
+        )
 
     return pathlib.Path(dest_path).as_uri()
 

--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -193,7 +193,7 @@ def _download_file(callback, src_bucket, src_key, src_version, dest_path, overri
         # this indicates that the destination path is on an OS that doesn't support xattrs
         # if this is the case, raise a warning and leave xattrs blank
         warnings.warn(
-            f'Could not write file xattrs for destination {dest_path}.'
+            f'Could not write file xattrs for destination "{dest_path!r}".'
         )
 
     return pathlib.Path(dest_path).as_uri()


### PR DESCRIPTION
Currently fetch (and other commands, presumably, though I didn't test them) will fail when the directory targeted by the fetch does not support xattrs. This is perhaps archaic, but possible with certain systems and servers, and is in fact [exactly the situation that Jackson ran into](https://quiltusers.slack.com/archives/C1QMGJTT2/p1554665285028600) when fetching to a Dell Isilon NAT instance.

If the fetch target doesn't support xattrs, instead of failing outright it is more friendly to write the file anyway and warn the user. xattr write failure has only minor implications for the user:

* When you add a local file to a package (via `set` or `set_dir`), an entry in `xattrs` constituting a deserialization type hint on the file is checked (this type hint is currently _only_ written to by `t4.Bucket.put`). If no xattrs are written, the API will fall back to using the file extension.
* `xattrs` are read from as default metadata (unless overwritten by your own custom `meta=`). xattrs that don't land don't have this defaulting behavior.

This PR is per user request: https://quiltusers.slack.com/archives/C1QMGJTT2/p1554665285028600.