### PR TITLE
Don't quote in xattr error text

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -193,7 +193,7 @@ def _download_file(callback, src_bucket, src_key, src_version, dest_path, overri
         # this indicates that the destination path is on an OS that doesn't support xattrs
         # if this is the case, raise a warning and leave xattrs blank
         warnings.warn(
-            f'Could not write file xattrs for destination "{dest_path!r}".'
+            f'Could not write file xattrs for destination {dest_path!r}.'
         )
 
     return pathlib.Path(dest_path).as_uri()


### PR DESCRIPTION
The previous PR added an error substring formatted `"{foo!r}"`. But using `!r` in this context wraps in single quote (`'`) automatically. So instead of getting `"some/path"` (as intended) in the error string you get `"'some/path'"`. Dropping the quotes means we get `'some/path'`, which is better.