### PR TITLE
Pin ipywidgets

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -68,7 +68,8 @@ setup(
         'six>=1.10.0',
         'tqdm>=4.26.0',
         'xattr>=0.9.6; platform_system!="Windows"',
-        'humanize'
+        'humanize',
+        'ipywidgets>=0.6.0'                 # required by tqdm.autonotebook
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
Pinning to `ipywidgets>0.6.0` as a dependency should address the `ipywidgets`-not-installed error on `tqdm.autonotebook` we've been seeing from users.