### PR TITLE
Warn the user when the size of a remote object changes in between set time and push time

### DIFF
--- a/api/python/t4/data_transfer.py
+++ b/api/python/t4/data_transfer.py
@@ -634,11 +634,11 @@ def calculate_sha256(src_list, sizes, total_size):
                     old_size = humanize.naturalsize(size)
                     new_size = humanize.naturalsize(current_obj_size)
                     warnings.warn(
-                        f"Expected the package entry at {src!r} to be {old_size} large, but "
+                        f"Expected the package entry at {src!r} to be {old_size} in size, but "
                         f"found an object which is {new_size} instead. This indicates that the "
-                        f"content of the content of the file changed in between when you "
-                        f"included this entry in the package (via set or set_dir) and now. This "
-                        f"should be avoided if possible."
+                        f"content of the file changed in between when you included this entry "
+                        f"in the package (via set or set_dir) and now. This should be avoided "
+                        f"if possible."
                     )
 
                 body = resp['Body']

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -648,8 +648,9 @@ class Package(object):
             return
 
         physical_keys = (entry.physical_keys[0] for entry in entries)
+        sizes = (entry.size for entry in entries)
         total_size = sum(entry.size for entry in entries)
-        results = calculate_sha256(physical_keys, total_size)
+        results = calculate_sha256(physical_keys, sizes, total_size)
 
         for entry, obj_hash in zip(entries, results):
             entry.hash = dict(type='SHA256', value=obj_hash)


### PR DESCRIPTION
Currently we performance an existence check for files on S3 that we include in a `Package` via `set`. I wanted to remove this network request in the interest of transparency vis-a-vis the user expectation of what "set" does, but I backtracked on this pending further discussion b/c existence checks are highly useful (thanks @stevededalus).

However, the fact that we rely on the size of the `PackageEntry` as set at `set` time creates a footgun: we don't notice if the entry changes in size, which leads to an inaccurate progress bar.

This PR adds a warning that informs the user of changes in the size of a `PackageEntry` in between `set` time and `push` time, if such changes do in fact occur.