### PR TITLE
Improvements to list_packages

### DIFF
--- a/api/python/t4/api.py
+++ b/api/python/t4/api.py
@@ -266,26 +266,29 @@ def list_packages(registry=None):
                         f"{self._fmt_str(size_str, 15).rstrip(' ')}\t\n")
             return out
 
+    # get_package_registry may include '/.quilt', which Package.browse does not expect
     if registry is None or registry == 'local':
-        base_registry = get_package_registry(None)
+        package_registry = None
     else:
-        base_registry = get_package_registry(fix_url(registry))
+        package_registry = fix_url(registry)
 
-    named_packages = base_registry + '/named_packages'
+    base_registry = get_package_registry(package_registry)
+    registry = base_registry.rstrip('.quilt/')
+    named_packages_path = urlparse(base_registry + '/named_packages')
+    registry_scheme = named_packages_path.scheme
 
     pkg_info = []
 
-    registry_url = urlparse(named_packages)
-    if registry_url.scheme == 'file':
-        registry_dir = pathlib.Path(parse_file_url(registry_url))
+    if registry_scheme == 'file':
+        registry_dir = pathlib.Path(parse_file_url(named_packages_path))
 
         for named_path in registry_dir.glob('*/*'):
-            name = named_path.relative_to(registry_dir).as_posix()
+            pkg_name = named_path.relative_to(registry_dir).as_posix()
 
             pkg_hashes = []
             pkg_sizes = []
             pkg_ctimes = []
-            pkg_name = name
+            pkg_display_names = []
 
             with open(named_path / 'latest', 'r') as latest_hash_file:
                 latest_hash = latest_hash_file.read()
@@ -299,20 +302,26 @@ def list_packages(registry=None):
                     pkg_hashes.append(pkg_hash)
 
                 if pkg_hash == latest_hash:
-                    pkg_name = f'{pkg_name}:latest'
+                    pkg_display_name = f'{pkg_name}:latest'
+                else:
+                    pkg_display_name = pkg_name
 
                 pkg_ctimes.append(pkg_hash_path.stat().st_ctime)
 
-                pkg = Package.browse(name, registry='local', top_hash=pkg_hash)
+                pkg = Package.browse(pkg_name, registry=registry, top_hash=pkg_hash)
                 pkg_sizes.append(pkg.reduce(lambda tot, tup: tot + tup[1].size, default=0))
+                pkg_display_names.append(pkg_display_name)
 
-            for top_hash, ctime, size in zip(pkg_hashes, pkg_ctimes, pkg_sizes):
+            for pkg_display_name, top_hash, ctime, size in zip(
+                    pkg_display_names, pkg_hashes, pkg_ctimes, pkg_sizes
+            ):
                 pkg_info.append(
-                    {'pkg_name': pkg_name, 'top_hash': top_hash, 'ctime': ctime, 'size': size}
+                    {'pkg_name': pkg_display_name, 'top_hash': top_hash,
+                     'ctime': ctime, 'size': size}
                 )
 
-    elif registry_url.scheme == 's3':
-        bucket_name, bucket_registry_path, _ = parse_s3_url(registry_url)
+    elif registry_scheme == 's3':
+        bucket_name, bucket_registry_path, _ = parse_s3_url(named_packages_path)
         bucket_registry_path = bucket_registry_path + '/'
 
         pkg_namespaces, _ = list_objects(bucket_name, bucket_registry_path, recursive=False)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -494,7 +494,7 @@ class PackageTest(QuiltTestCase):
 
     def test_list_local_packages(self):
         """Verify that list returns packages in the appdirs directory."""
-        temp_local_registry = Path('test_registry').resolve().as_uri()
+        temp_local_registry = Path('test_registry').resolve().as_uri() + '/.quilt'
         with patch('t4.packages.get_package_registry', lambda path: temp_local_registry), \
             patch('t4.api.get_package_registry', lambda path: temp_local_registry):
             # Build a new package into the local registry.

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -511,6 +511,11 @@ class PackageTest(QuiltTestCase):
             # Verify 'local' keyword works as expected.
             assert list(pkgs) == list(t4.list_packages('local'))
 
+            # Verify specifying a local path explicitly works as expected.
+            assert list(pkgs) == list(t4.list_packages(
+                pathlib.Path(temp_local_registry).parent.as_posix()
+            ))
+
             # Verify package repr is as expected.
             pkgs_repr = str(pkgs)
             assert 'Quilt/Test:latest' in pkgs_repr


### PR DESCRIPTION
This PR does three things:

1. Previously `t4.list_packages` was hard-coded to go to the `local` registry when referencing a registry with the `file` schema, which was an oversight on my part (thanks Jackson for the spot!)
2. Fixed a bug with `latest`. The current implementation naively assumes only one package has a `tophash` corresponding with `latest`, which is untrue: `build` can generate arbitrarily many sequential packages with the same `tophash` (but potentially with different physical keys). This could result in packages whose display name is `a/b:latest:latest`. This PR fixes this issue.
3. Refactored a few method name to make them easier to understand.