### PR TITLE
Use unittest mock instead of mock

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -74,7 +74,6 @@ setup(
     extras_require={
         'tests': [
             'codecov',
-            'mock',   # XXX correct syntax for extras_require?
             'pytest',
             'pytest-cov',
             'responses',

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import shutil
 
 import jsonlines
-from mock import patch, call, ANY
+from unittest.mock import patch, call, ANY
 import pytest
 
 import t4

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -1,5 +1,5 @@
 import json
-from mock import patch
+from unittest.mock import patch
 import pathlib
 from urllib.parse import urlparse
 

--- a/api/python/tests/test_search.py
+++ b/api/python/tests/test_search.py
@@ -1,6 +1,5 @@
 import json
-from mock import patch
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock
 
 from t4 import Bucket
 


### PR DESCRIPTION
We are using the `mock` [PyPi package](https://pypi.org/project/mock/) in our tests. However, `mock` was merged into Python stdlib in py3.3 as `unittest.mock`. The PyPi package is no longer maintained.

This PR updates all references to `mock` to `unittest.mock` and removes `mock` from the `extras_require` section of our `setup.py`.