### PR TITLE
Rename t4.Bucket user_meta args to meta

### DIFF
--- a/api/python/t4/bucket.py
+++ b/api/python/t4/bucket.py
@@ -125,16 +125,16 @@ class Bucket(object):
         """
         return self.deserialize(key)
 
-    def put(self, key, obj, user_meta=None):
+    def put(self, key, obj, meta=None):
         """
         Stores `obj` at key in bucket, optionally with user-provided metadata.
 
         Args:
             key(str): key in bucket to put object to
             obj(serializable): serializable object to store at key
-            user_meta(dict): optional user-provided metadata to store
+            meta(dict): optional user-provided metadata to store
         """
-        user_meta = user_meta or {}
+        user_meta = meta or {}
         dest = self._uri + key
         all_meta = {
             'user_meta': user_meta
@@ -143,7 +143,7 @@ class Bucket(object):
         all_meta.update(format_meta)
         put_bytes(data, dest, all_meta)
 
-    def put_file(self, key, path, user_meta=None):
+    def put_file(self, key, path, meta=None):
         """
         Stores file at path to key in bucket.
 
@@ -151,7 +151,7 @@ class Bucket(object):
             key(str): key in bucket to store file at
             path(str): string representing local path to file
         Optional args:
-            user_meta(dict): T4 metadata to attach to file
+            meta(dict): T4 metadata to attach to file
                 Must be less than 2KiB serialized
 
         Returns:
@@ -161,12 +161,12 @@ class Bucket(object):
             * if no file exists at path
             * if copy fails
         """
-        user_meta = user_meta or {}
+        user_meta = meta or {}
         dest = self._uri + key
-        meta = {
+        all_meta = {
             'user_meta': user_meta
         }
-        copy_file(fix_url(path), dest, meta)
+        copy_file(fix_url(path), dest, all_meta)
 
     def put_dir(self, key, directory):
         """

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -178,7 +178,7 @@ class TestBucket(QuiltTestCase):
             expected_meta = {
                 'user_meta': test_meta
             }
-            bucket.put_file(key='README.md', path='./README', user_meta=test_meta)
+            bucket.put_file(key='README.md', path='./README', meta=test_meta)
             (src, dest, meta) = copy_mock.call_args_list[0][0]
             assert meta == expected_meta
 

--- a/docs/API Reference/Bucket.md
+++ b/docs/API Reference/Bucket.md
@@ -79,7 +79,7 @@ __Arguments__
 * __key__:  Key of object to deserialize.
 
 
-## Bucket.put(self, key, obj, meta=None)  {#Bucket.put}
+## Bucket.put(self, key, obj, user\_meta=None)  {#Bucket.put}
 
 Stores `obj` at key in bucket, optionally with user-provided metadata.
 
@@ -87,10 +87,10 @@ __Arguments__
 
 * __key(str)__:  key in bucket to put object to
 * __obj(serializable)__:  serializable object to store at key
-* __meta(dict)__:  optional user-provided metadata to store
+* __user_meta(dict)__:  optional user-provided metadata to store
 
 
-## Bucket.put\_file(self, key, path, meta=None)  {#Bucket.put\_file}
+## Bucket.put\_file(self, key, path, user\_meta=None)  {#Bucket.put\_file}
 
 Stores file at path to key in bucket.
 
@@ -99,7 +99,7 @@ __Arguments__
 * __key(str)__:  key in bucket to store file at
 * __path(str)__:  string representing local path to file
 Optional args:
-    meta(dict): T4 metadata to attach to file
+    user_meta(dict): T4 metadata to attach to file
         Must be less than 2KiB serialized
 
 __Returns__

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -2,7 +2,7 @@
 # t4
 T4 API
 
-## config(\*autoconfig\_url, \*\*config\_values)  {#config}
+## config(\*catalog\_url, \*\*config\_values)  {#config}
 Set or read the T4 configuration.
 
 To retrieve the current config, call directly, without arguments:
@@ -25,30 +25,16 @@ To set config values, call with one or more key=value pairs:
     ...           elastic_search_url='http://example.com/queries')
 ```
 
-When setting config values, unrecognized values are rejected.  Acceptable
-config values can be found in `t4.util.CONFIG_TEMPLATE`.
+Default config values can be found in `t4.util.CONFIG_TEMPLATE`.
 
 __Arguments__
 
-* __autoconfig_url__:  A (single) URL indicating a location to configure from
+* __catalog_url__:  A (single) URL indicating a location to configure from
 * __**config_values__:  `key=value` pairs to set in the config
 
 __Returns__
 
 `T4Config`: (an ordered Mapping)
-
-
-## copy(src, dest)  {#copy}
-
-Copies ``src`` object from T4 to ``dest``.
-
-Either of ``src`` and ``dest`` may be S3 paths (starting with ``s3://``)
-or local file paths (starting with ``file:///``).
-
-__Arguments__
-
-* __src (str)__:  a path to retrieve
-* __dest (str)__:  a path to write to
 
 
 ## delete\_package(name, registry=None)  {#delete\_package}
@@ -59,20 +45,6 @@ __Arguments__
 
 * __name (str)__:  Name of the package
 * __registry (str)__:  The registry the package will be removed from
-
-
-## get(src)  {#get}
-Retrieves src object from T4 and loads it into memory.
-
-An optional ``version`` may be specified.
-
-__Arguments__
-
-* __src (str)__:  A URI specifying the object to retrieve
-
-__Returns__
-
-`tuple`: ``(data, metadata)``.  Does not work on all objects.
 
 
 ## list\_packages(registry=None)  {#list\_packages}
@@ -88,35 +60,4 @@ __Arguments__
 __Returns__
 
 A list of strings containing the names of the packages
-
-
-## put(obj, dest, meta=None)  {#put}
-Write an in-memory object to the specified T4 ``dest``.
-
-Note:
-    Does not work with all objects -- object must be serializable.
-
-You may pass a dict to ``meta`` to store it with ``obj`` at ``dest``.
-
-__Arguments__
-
-* __obj__:  a serializable object
-* __dest (str)__:  A URI
-* __meta (dict)__:  Optional. metadata dict to store with ``obj`` at ``dest``
-
-
-## search(query)  {#search}
-
-Searches your bucket. query can contain plaintext, and can also contain clauses
-like $key:"$value" that search for exact matches on specific keys.
-
-Returns either the request object (in case of an error) or a list of objects with the following keys:
-    key: key of the object
-    version_id: version_id of object version
-    operation: Create or Delete
-    meta: metadata attached to object
-    size: size of object in bytes
-    text: indexed text of object
-    source: source document for object (what is actually stored in ElasticSeach)
-    time: timestamp for operation
 

--- a/gendocs/pydocmd.yml
+++ b/gendocs/pydocmd.yml
@@ -12,12 +12,8 @@ generate:
     # might just want to specify "__all__" in t4.__init__ and use 't4+' on the
     # line above this comment.  Specified explicitly for this example.
     - t4.config
-    - t4.copy
     - t4.delete_package
-    - t4.get
     - t4.list_packages
-    - t4.put
-    - t4.search
 # Uncomment the following two lines in include these classes directly in api.md
 #    - Bucket+
 #    - Package+


### PR DESCRIPTION
This argument is consistently `meta` throughout the rest of the user-facing API.