### PR TITLE
API enhancements for search

### DIFF
--- a/api/python/t4/search_util.py
+++ b/api/python/t4/search_util.py
@@ -76,11 +76,13 @@ def search(query, search_endpoint, limit, aws_region='us-east-1'):
 
     if isinstance(query, dict):
         payload = query
-    else:
+    elif isinstance(query, str):
         payload = {'query': {'query_string': {
             'default_field': 'content',
             'query': query,
         }}}
+    else:
+        raise QuiltException('Value provided for `query` is invalid')
 
     if limit:
         payload['size'] = limit

--- a/api/python/t4/search_util.py
+++ b/api/python/t4/search_util.py
@@ -74,10 +74,13 @@ def search(query, search_endpoint, limit, aws_region='us-east-1'):
     """
     es_client = _create_es(search_endpoint, aws_region)
 
-    payload = {'query': {'query_string': {
-        'default_field': 'content',
-        'query': query,
-    }}}
+    if isinstance(query, dict):
+        payload = query
+    else:
+        payload = {'query': {'query_string': {
+            'default_field': 'content',
+            'query': query,
+        }}}
 
     if limit:
         payload['size'] = limit
@@ -113,7 +116,7 @@ def search(query, search_endpoint, limit, aws_region='us-east-1'):
         setattr(exception, 'raw_response', raw_response)
         raise exception
 
-def get_raw_mapping_unpacked(endpoint, aws_region):
+def get_raw_mapping_unpacked(endpoint, aws_region, return_full_response=False):
     """
     Gets raw mapping from Elasticsearch
 
@@ -138,6 +141,8 @@ def get_raw_mapping_unpacked(endpoint, aws_region):
     """
     es_client = _create_es(endpoint, aws_region)
     raw_response = es_client.indices.get_mapping(index=ES_INDEX)
+    if return_full_response:
+        return raw_response
     return raw_response['drive']['mappings']['_doc']
 
 def get_search_schema(endpoint, aws_region):

--- a/api/python/tests/test_search.py
+++ b/api/python/tests/test_search.py
@@ -109,3 +109,14 @@ def test_bucket_search():
         results = bucket.search('*')
         assert es_mock.search.called_with('*', 'test')
         assert len(results) == 1
+
+        query = {
+            'query': {
+                'term': {
+                    'key': '*'
+                }
+            }
+        }
+        results = bucket.search(query)
+        assert es_mock.search.called_with('*', 'test')
+        assert len(results) == 1


### PR DESCRIPTION
Allows searching using Elastic's full Query DSL. Also allows getting the full mappings response when desired.