### PR TITLE
Sync READMEs, indicate production ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![docs on_gitbook](https://img.shields.io/badge/docs-on_gitbook-blue.svg?style=flat-square)](https://quiltdocs.gitbook.io/t4/)
 [![chat on_slack](https://img.shields.io/badge/chat-on_slack-blue.svg?style=flat-square)](https://slack.quiltdata.com/)
 [![codecov](https://codecov.io/gh/quiltdata/t4/branch/master/graph/badge.svg)](https://codecov.io/gh/quiltdata/t4)
+[![pypi](https://img.shields.io/pypi/v/t4.svg?style=flat-square)](https://pypi.org/project/t4/)
 
 # Alpha - technology preview
 
@@ -34,10 +35,11 @@ T4 is alpha software. It is not yet recommended for production use.
 * Read/write Python objects to and from S3
 * Immutable versions for objects, immutable packages for collections of objects
 
-## Roadmap
-* [Roadmap](https://github.com/quiltdata/t4/blob/master/Roadmap.md)
-
-
 ## Components
+
 * `/catalog` (JavaScript) - Search, browse, and preview your data in S3
 * `/api/python` - Read, write, and annotate Python objects in S3
+
+## Roadmap
+
+* [Roadmap](https://github.com/quiltdata/t4/blob/master/Roadmap.md)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@
 [![codecov](https://codecov.io/gh/quiltdata/t4/branch/master/graph/badge.svg)](https://codecov.io/gh/quiltdata/t4)
 [![pypi](https://img.shields.io/pypi/v/t4.svg?style=flat-square)](https://pypi.org/project/t4/)
 
-# Alpha - technology preview
-
-T4 is alpha software. It is not yet recommended for production use.
 
 ## Overview
 [Rethinking S3: Announcing T4, a team data hub](https://blog.quiltdata.com/rethinking-s3-announcing-t4-a-team-data-hub-8e63ce7ec988).

--- a/docs/Further Reading.md
+++ b/docs/Further Reading.md
@@ -4,4 +4,4 @@ Some highlights on T4 from the [Quilt Blog](https://blog.quiltdata.com/):
 * ["Managing data science projects in S3&mdash;an introduction to Quilt T4"](https://blog.quiltdata.com/using-quilts-t4-to-manage-an-s3-hosted-data-science-project-7332fc463e89)
 * ["Reproduce a machine learning model build in four lines of code"](https://blog.quiltdata.com/reproduce-a-machine-learning-model-build-in-four-lines-of-code-b4f0a5c5f8c8)
 
-We also recommend checking out [our demo catalog](https://alpha.quiltdata.com/b/quilt-example), if you haven't done so already.
+We also recommend checking out [our demo catalog](https://aics.quiltdata.com/b/quilt-example), if you haven't done so already.

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,1 +1,1 @@
-For an introduction to the T4 Python API check out [the QuickStart notebook](https://alpha.quiltdata.com/b/quilt-example/packages/aleksey/hurdat/tree/latest/) in our demo catalog.
+For an introduction to the T4 Python API check out [the QuickStart notebook](https://aics.quiltdata.com/b/quilt-example/packages/aleksey/hurdat/tree/latest/) in our demo catalog.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,6 @@
 [![codecov](https://codecov.io/gh/quiltdata/t4/branch/master/graph/badge.svg)](https://codecov.io/gh/quiltdata/t4)
 [![pypi](https://img.shields.io/pypi/v/t4.svg?style=flat-square)](https://pypi.org/project/t4/)
 
-# Alpha - technology preview
-
-T4 is alpha software. It is not yet recommended for production use.
 
 ## Overview
 [Rethinking S3: Announcing T4, a team data hub](https://blog.quiltdata.com/rethinking-s3-announcing-t4-a-team-data-hub-8e63ce7ec988).

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,6 @@ T4 is alpha software. It is not yet recommended for production use.
 * `/catalog` (JavaScript) - Search, browse, and preview your data in S3
 * `/api/python` - Read, write, and annotate Python objects in S3
 
-## Documentation
-* [Docs](https://quiltdocs.gitbook.io/t4/)
+## Roadmap
+
 * [Roadmap](https://github.com/quiltdata/t4/blob/master/Roadmap.md)

--- a/docs/Walkthrough/Working with a Bucket.md
+++ b/docs/Walkthrough/Working with a Bucket.md
@@ -79,7 +79,7 @@ Note that this feature is currently only supported for buckets backed by a T4 ca
 
 ```python
 # for example
-t4.config(navigator_url="https://alpha.quiltdata.com")
+t4.config(navigator_url="https://aics.quiltdata.com")
 ```
 
 T4 supports unstructured search:

--- a/docs/Walkthrough/Working with the Catalog.md
+++ b/docs/Walkthrough/Working with the Catalog.md
@@ -1,6 +1,6 @@
 The Quilt T4 Catalog is the second half of Quilt T4. It provides an interface on top of your S3 bucket that brings T4 features like data packages and search to the web.
 
-**[To get a hands on demo, check out the public demo catalog](https://alpha.quiltdata.com/b/quilt-example).**
+**[To get a hands on demo, check out the public demo catalog](https://aics.quiltdata.com/b/quilt-example).**
 
 Note that you can use the T4 Python API without using the catalog product, but they are designed to work together.
 
@@ -47,4 +47,4 @@ The admin page is only accessible to catalog admins. Only admins may create othe
 
 You may invite new users to collaborate on your T4 bucket via email, again from the admin interface.
 
-**[To learn more, check out the public demo catalog](https://alpha.quiltdata.com/b/quilt-example)**.
+**[To learn more, check out the public demo catalog](https://aics.quiltdata.com/b/quilt-example)**.

--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -86,7 +86,7 @@ def extract_text(notebook_str):
         * Deliberately decided not to index output streams and display strings
         because they were noisy and low value
         * Tested this code against ~6400 Jupyter notebooks in
-        https://alpha.quiltdata.com/b/alpha-quilt-storage/tree/notebook-search/
+        s3://alpha-quilt-storage/tree/notebook-search/
         * Might be useful to index "cell_type" : "raw" in the future
     See also:
         * Format reference https://nbformat.readthedocs.io/en/latest/format_description.html

--- a/lambdas/es/indexer/test/test_read_notebook.py
+++ b/lambdas/es/indexer/test/test_read_notebook.py
@@ -24,7 +24,7 @@ NB_EXTRACTS = {
 def test_extract_text():
     """ test extraction of code + markdown with format_notebook
     this code was developed after running format_notebook on ~6400 notebooks
-    found here https://alpha.quiltdata.com/b/alpha-quilt-storage/tree/notebook-search/
+    found here s3://alpha-quilt-storage/tree/notebook-search/
     """
     parent = os.path.dirname(__file__)
     basedir = os.path.join(parent, 'data')


### PR DESCRIPTION
* Remove ~alpha~ caveats
* Remove bad links to alpha.quiltdata.com (old stack)
* Will need to update stack links again when we have a user-facing sandbox