### PR TITLE
Simplify the user-facing metadata API

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -117,7 +117,7 @@ class PackageEntry(object):
     def meta(self):
         return self._meta.get('user_meta', dict())
 
-    def set_user_meta(self, meta):
+    def set_meta(self, meta):
         """
         Sets the user_meta for this PackageEntry.
         """
@@ -155,7 +155,7 @@ class PackageEntry(object):
             self.size = None
             self.hash = None
         elif meta is not None:
-            self.set_user_meta(meta)
+            self.set_meta(meta)
         else:
             raise PackageException('Must specify either path or meta')
 
@@ -861,7 +861,7 @@ class Package(object):
         else:
             raise TypeError("Expected a string for entry")
         if meta is not None:
-            entry.set_user_meta(meta)
+            entry.set_meta(meta)
 
         path = self._split_key(logical_key)
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -478,18 +478,18 @@ class PackageTest(QuiltTestCase):
             .set('foo', DATA_DIR / 'foo.txt', {'value': 'blah'})
             .set('bar', DATA_DIR / 'foo.txt', {'value': 'blah2'})
         )
-        pkg['foo'].meta['target'] = 'unicode'
-        pkg['bar'].meta['target'] = 'unicode'
+        pkg['foo']._meta['target'] = 'unicode'
+        pkg['bar']._meta['target'] = 'unicode'
 
         assert pkg['foo'].meta == {'value': 'blah'}
         assert pkg['bar'].meta == {'value': 'blah2'}
 
-        assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah'}}
-        assert pkg['bar'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah2'}}
+        assert pkg['foo']._meta == {'target': 'unicode', 'user_meta': {'value': 'blah'}}
+        assert pkg['bar']._meta == {'target': 'unicode', 'user_meta': {'value': 'blah2'}}
 
-        pkg['foo'].set_user_meta({'value': 'other value'})
+        pkg['foo'].set_meta({'value': 'other value'})
         assert pkg['foo'].meta == {'value': 'other value'}
-        assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'other value'}}
+        assert pkg['foo']._meta == {'target': 'unicode', 'user_meta': {'value': 'other value'}}
 
 
     def test_list_local_packages(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -391,7 +391,7 @@ class PackageTest(QuiltTestCase):
         assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
         assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_keys[0]
         assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_keys[0]
-        assert pkg.get_meta() == "test_meta"
+        assert pkg.meta == "test_meta"
 
         pkg = Package()
         pkg = pkg.set_dir('/','foo_dir/baz_dir/')
@@ -432,7 +432,7 @@ class PackageTest(QuiltTestCase):
 
         assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_keys[0]
         assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_keys[0]
-        assert pkg['new_dir'].get_meta() == "new_test_meta"
+        assert pkg['new_dir'].meta == "new_test_meta"
 
         # verify set_dir logical key shortcut
         pkg = Package()
@@ -456,7 +456,7 @@ class PackageTest(QuiltTestCase):
 
             assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
             assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
-            assert pkg.get_meta() == "test_meta"
+            assert pkg.meta == "test_meta"
             assert pkg['x']['y.txt'].size == 10  # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
@@ -481,14 +481,14 @@ class PackageTest(QuiltTestCase):
         pkg['foo'].meta['target'] = 'unicode'
         pkg['bar'].meta['target'] = 'unicode'
 
-        assert pkg['foo'].get_user_meta() == {'value': 'blah'}
-        assert pkg['bar'].get_user_meta() == {'value': 'blah2'}
+        assert pkg['foo'].meta == {'value': 'blah'}
+        assert pkg['bar'].meta == {'value': 'blah2'}
 
         assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah'}}
         assert pkg['bar'].meta == {'target': 'unicode', 'user_meta': {'value': 'blah2'}}
 
         pkg['foo'].set_user_meta({'value': 'other value'})
-        assert pkg['foo'].get_user_meta() == {'value': 'other value'}
+        assert pkg['foo'].meta == {'value': 'other value'}
         assert pkg['foo'].meta == {'target': 'unicode', 'user_meta': {'value': 'other value'}}
 
 
@@ -730,23 +730,23 @@ class PackageTest(QuiltTestCase):
         pkg.set('qwer/asdf', LOCAL_MANIFEST)
         pkg.set('qwer/as/df', LOCAL_MANIFEST)
         pkg.build()
-        assert pkg['asdf'].get_meta() == {}
-        assert pkg.get_meta() == {}
-        assert pkg['qwer']['as'].get_meta() == {}
+        assert pkg['asdf'].meta == {}
+        assert pkg.meta == {}
+        assert pkg['qwer']['as'].meta == {}
         pkg['asdf'].set_meta(test_meta)
-        assert pkg['asdf'].get_meta() == test_meta
+        assert pkg['asdf'].meta == test_meta
         pkg['qwer']['as'].set_meta(test_meta)
-        assert pkg['qwer']['as'].get_meta() == test_meta
+        assert pkg['qwer']['as'].meta == test_meta
         pkg.set_meta(test_meta)
-        assert pkg.get_meta() == test_meta
+        assert pkg.meta == test_meta
         dump_path = 'test_meta'
         with open(dump_path, 'w') as f:
             pkg.dump(f)
         with open(dump_path) as f:
             pkg2 = Package.load(f)
-        assert pkg2['asdf'].get_meta() == test_meta
-        assert pkg2['qwer']['as'].get_meta() == test_meta
-        assert pkg2.get_meta() == test_meta
+        assert pkg2['asdf'].meta == test_meta
+        assert pkg2['qwer']['as'].meta == test_meta
+        assert pkg2.meta == test_meta
 
     def test_top_hash_stable(self):
         """Ensure that top_hash() never changes for a given manifest"""

--- a/docs/Walkthrough/Reading from a Package.md
+++ b/docs/Walkthrough/Reading from a Package.md
@@ -82,15 +82,15 @@ p.get()
 
 ## Getting metadata
 
-Entries, folders, and the package itself may all have associated metadata, which you can use `get_meta` to retrieve:
+Metadata is available using the `meta` property.
 
 ```python
 # get entry metadata
-p["commodities"]["gold.csv"].get_meta()
+p["commodities"]["gold.csv"].meta
 
 # get directory metadata
-p["commodities"].get_meta()
+p["commodities"].meta
 
 # get package metadata
-p.get_meta()
+p.meta
 ```


### PR DESCRIPTION
Differences in behavior:

• Removed `get_meta`, `get_user_meta` in favor of a more Pythonic `.meta` accessor. So now to get metadata on a package or a package entry, just do `pkg.meta` or `pkg_entry.meta`.
• Standardized empty metadata behavior. Now is you can `.meta` you will always get an empty dict `{}` if there is no metadata. Previously you would get either an empty dict or `None`, depending on the code path.
• `meta` returns the _actual_ metadata you set on the object, no `user_meta` key!

This has nice implications for e.g. filtering. From:

```p.filter(_, entry: do_something(entry.get_meta()['user_meta']))```

To:

```p.filter(_, entry: do_something(entry.meta))```