### PR TITLE
Multi-bucket support for notification configuration lambda

### DIFF
--- a/lambdas/notification-configuration/index.py
+++ b/lambdas/notification-configuration/index.py
@@ -54,7 +54,12 @@ def handler(event, context):
     print('Changing bucket notification settings')
     try:
         params = select_params(event['ResourceProperties'])
-        current_resource_id = 'notification_' + params['Bucket']
+        bucket = params['Bucket']
+        current_resource_id = 'notification_' + bucket
+        if bucket == '':
+            print('Bucket is empty string, doing nothing and returning success')
+            send(event, context, SUCCESS, physical_resource_id=current_resource_id)
+            return
         if event['RequestType'] == 'Create':
             set_mappings(params)
             send(event, context, SUCCESS, physical_resource_id=current_resource_id)


### PR DESCRIPTION
Just no-ops on an empty string bucket. Will be useful for adding multi-bucket support to the template (current plan is to create one copy of each custom resource for each bucket, but we'll need a placeholder value in case users have less than the maximum number of allowed buckets. Empty string is a good sentinel value).