### PR TITLE
Improve some packages tests

### DIFF
--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -302,50 +302,86 @@ class PackageTest(QuiltTestCase):
 
     def test_load_into_t4(self):
         """ Verify loading local manifest and data into S3. """
-        with patch('t4.packages.put_bytes') as bytes_mock, \
-            patch('t4.data_transfer._upload_file') as file_mock, \
-            patch('t4.packages.get_from_config') as config_mock:
-            file_mock.return_value = 'foo.txt'
-            config_mock.return_value = 's3://my_test_bucket'
-            new_pkg = Package()
-            # Create a dummy file to add to the package.
-            contents = 'blah'
-            test_file = Path('bar')
-            test_file.write_text(contents)
-            new_pkg = new_pkg.set('foo', test_file)
+        top_hash = '5333a204bbc6e21607c2bc842f4a77d2e21aa6147cf2bf493dbf6282188d01ca'
+
+        self.s3_stubber.add_response(
+            method='put_object',
+            service_response={
+                'VersionId': 'v1'
+            },
+            expected_params={
+                'Body': ANY,
+                'Bucket': 'my_test_bucket',
+                'Key': 'Quilt/package/foo',
+                'Metadata': {'helium': '{}'}
+            }
+        )
+
+        self.s3_stubber.add_response(
+            method='put_object',
+            service_response={
+                'VersionId': 'v2'
+            },
+            expected_params={
+                'Body': ANY,
+                'Bucket': 'my_test_bucket',
+                'Key': '.quilt/packages/' + top_hash,
+                'Metadata': {'helium': 'null'}
+            }
+        )
+
+        self.s3_stubber.add_response(
+            method='put_object',
+            service_response={
+                'VersionId': 'v3'
+            },
+            expected_params={
+                'Body': top_hash.encode(),
+                'Bucket': 'my_test_bucket',
+                'Key': '.quilt/named_packages/Quilt/package/1234567890',
+                'Metadata': {'helium': 'null'}
+            }
+        )
+
+        self.s3_stubber.add_response(
+            method='put_object',
+            service_response={
+                'VersionId': 'v4'
+            },
+            expected_params={
+                'Body': top_hash.encode(),
+                'Bucket': 'my_test_bucket',
+                'Key': '.quilt/named_packages/Quilt/package/latest',
+                'Metadata': {'helium': 'null'}
+            }
+        )
+
+        new_pkg = Package()
+        # Create a dummy file to add to the package.
+        contents = 'blah'
+        test_file = Path('bar')
+        test_file.write_text(contents)
+        new_pkg = new_pkg.set('foo', test_file)
+
+        with patch('time.time', return_value=1234567890):
             new_pkg.push('Quilt/package', 's3://my_test_bucket/')
 
-            # Manifest copied
-            top_hash = new_pkg.top_hash
-            bytes_mock.assert_any_call(top_hash.encode(), 's3://my_test_bucket/.quilt/named_packages/Quilt/package/latest')
-            bytes_mock.assert_any_call(ANY, 's3://my_test_bucket/.quilt/packages/' + top_hash)
-
-            # Data copied
-            file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), 'my_test_bucket', 'Quilt/package/foo', {})
-
     def test_local_push(self):
-        """ Verify loading local manifest and data into S3. """
-        with patch('t4.packages.put_bytes') as bytes_mock, \
-            patch('t4.data_transfer._copy_local_file') as file_mock, \
-            patch('t4.packages.get_from_config') as config_mock:
-            file_mock.return_value = 'foo.txt'
-            config_mock.return_value = 'package_contents'
-            new_pkg = Package()
-            contents = 'blah'
-            test_file = Path('bar')
-            test_file.write_text(contents)
-            new_pkg = new_pkg.set('foo', test_file)
-            new_pkg.push('Quilt/package', 'package_contents')
+        """ Verify loading local manifest and data into a local dir. """
+        top_hash = '5333a204bbc6e21607c2bc842f4a77d2e21aa6147cf2bf493dbf6282188d01ca'
 
-            push_uri = Path('package_contents').resolve().as_uri()
+        new_pkg = Package()
+        contents = 'blah'
+        test_file = Path('bar')
+        test_file.write_text(contents)
+        new_pkg = new_pkg.set('foo', test_file)
+        new_pkg.push('Quilt/package', 'package_contents')
 
-            # Manifest copied
-            top_hash = new_pkg.top_hash
-            bytes_mock.assert_any_call(top_hash.encode(), push_uri + '/.quilt/named_packages/Quilt/package/latest')
-            bytes_mock.assert_any_call(ANY, push_uri + '/.quilt/packages/' + top_hash)
+        push_dir = Path('package_contents')
 
-            # Data copied
-            file_mock.assert_called_once_with(ANY, len(contents), str(test_file.resolve()), str(Path('package_contents/Quilt/package/foo').resolve()), {})
+        assert (push_dir / '.quilt/named_packages/Quilt/package/latest').read_text() == top_hash
+        assert (push_dir / ('.quilt/packages/' + top_hash)).exists()
+        assert (push_dir / 'Quilt/package/foo').read_text() == contents
 
 
     def test_package_deserialize(self):


### PR DESCRIPTION
Don't mock data_transfer internals: it's fragile, and tests break every time we change the data_transfer code.
Instead,
- use S3 stubber for remote files
- don't mock local file operations at all - just check the file contents instead