### PR TITLE
Disallow "." and ".." file names and folder names in package keys

### DIFF
--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -852,7 +852,6 @@ class Package(object):
 
         if isinstance(entry, (string_types, getattr(os, 'PathLike', str))):
             url = fix_url(str(entry))
-            validate_key(url)
             size, orig_meta, version = get_size_and_meta(url)
 
             # Deterimine if a new version needs to be appended.
@@ -863,7 +862,6 @@ class Package(object):
                     url = make_s3_url(bucket, key, version)
             entry = PackageEntry([url], size, None, orig_meta)
         elif isinstance(entry, PackageEntry):
-            validate_key(_to_singleton(entry.physical_keys))
             entry = entry._clone()
         else:
             raise TypeError(

--- a/api/python/t4/packages.py
+++ b/api/python/t4/packages.py
@@ -851,9 +851,8 @@ class Package(object):
             entry = logical_key_abs_path.relative_to(current_working_dir)
 
         if isinstance(entry, (string_types, getattr(os, 'PathLike', str))):
-            entry_str = str(entry)
-            validate_key(entry_str)
-            url = fix_url(entry_str)
+            url = fix_url(str(entry))
+            validate_key(url)
             size, orig_meta, version = get_size_and_meta(url)
 
             # Deterimine if a new version needs to be appended.

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -376,9 +376,9 @@ def validate_key(key):
             f"Invalid key {key!r}. A package entry key cannot be empty."
         )
 
-    if ((key == '.' or '/./' in key or key.startswith('./') or key.endswith('/.')) or
-        (key == '..' or  '/../' in key or key.startswith('../') or key.endswith('/..'))):
-        raise QuiltException(
-            f"Invalid key {key!r}. "
-            f"A package entry key cannot contain a file or folder named '.' or '..' in its path."
-        )
+    for part in key.split('/'):
+        if part in ('', '.', '..'):
+            raise QuiltException(
+                f"Invalid key {key!r}. "
+                f"A package entry key cannot contain a file or folder named '.' or '..' in its path."
+            )

--- a/api/python/t4/util.py
+++ b/api/python/t4/util.py
@@ -366,3 +366,19 @@ def quiltignore_filter(paths, ignore, url_scheme):
         return files.union(dirs)
     else:
         raise NotImplementedError
+
+def validate_key(key):
+    """
+    Verify that a file path or S3 path does not contain any '.' or '..' separators or files.
+    """
+    if key is None or key == '':
+        raise QuiltException(
+            f"Invalid key {key!r}. A package entry key cannot be empty."
+        )
+
+    if ((key == '.' or '/./' in key or key.startswith('./') or key.endswith('/.')) or
+        (key == '..' or  '/../' in key or key.startswith('../') or key.endswith('/..'))):
+        raise QuiltException(
+            f"Invalid key {key!r}. "
+            f"A package entry key cannot contain a file or folder named '.' or '..' in its path."
+        )

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1051,41 +1051,6 @@ class PackageTest(QuiltTestCase):
             pkg.set('s3://foo/..', LOCAL_MANIFEST)
 
 
-    def test_invalid_key_dir(self):
-        # mock getting a list of files to include ones that break criteria
-        with patch('t4.packages.list_object_versions') as list_object_versions_mock:
-            # raises because of a '.' path separator
-            list_object_versions_mock.return_value = ([
-                dict(Key='foo/./bar.txt', VersionId='null', IsLatest=True, Size=10),
-            ], [])
-            with pytest.raises(QuiltException):
-                t4.Package().set_dir('foo', 's3://bucket/foo/')
-
-            # raises because of a '..' path separator
-            list_object_versions_mock.reset_mock()
-            list_object_versions_mock.return_value = ([
-                dict(Key='foo/../bar.txt', VersionId='null', IsLatest=True, Size=10),
-            ], [])
-            with pytest.raises(QuiltException):
-                t4.Package().set_dir('foo', 's3://bucket/foo/')
-
-            # raises because of a '.' object name
-            list_object_versions_mock.reset_mock()
-            list_object_versions_mock.return_value = ([
-                dict(Key='foo/.', VersionId='null', IsLatest=True, Size=10),
-            ], [])
-            with pytest.raises(QuiltException):
-                t4.Package().set_dir('foo', 's3://bucket/foo/')
-
-            # raises because of a '..' object name
-            list_object_versions_mock.reset_mock()
-            list_object_versions_mock.return_value = ([
-                dict(Key='foo/..', VersionId='null', IsLatest=True, Size=10),
-            ], [])
-            with pytest.raises(QuiltException):
-                t4.Package().set_dir('foo', 's3://bucket/foo/')
-
-
     def test_default_package_get_local(self):
         foodir = pathlib.Path("foo_dir")
         bazdir = pathlib.Path("baz_dir")

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1027,6 +1027,64 @@ class PackageTest(QuiltTestCase):
         with pytest.raises(QuiltException):
             pkg.set('foo', os.path.dirname(__file__))
 
+        # we do not allow '.' or '..' files or filename separators
+        with pytest.raises(QuiltException):
+            pkg.set('.', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('..', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('./foo', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('../foo', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo/.', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo/..', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo/./bar', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('foo/../bar', LOCAL_MANIFEST)
+
+        with pytest.raises(QuiltException):
+            pkg.set('s3://foo/.', LOCAL_MANIFEST)
+        with pytest.raises(QuiltException):
+            pkg.set('s3://foo/..', LOCAL_MANIFEST)
+
+
+    def test_invalid_key_dir(self):
+        # mock getting a list of files to include ones that break criteria
+        with patch('t4.packages.list_object_versions') as list_object_versions_mock:
+            # raises because of a '.' path separator
+            list_object_versions_mock.return_value = ([
+                dict(Key='foo/./bar.txt', VersionId='null', IsLatest=True, Size=10),
+            ], [])
+            with pytest.raises(QuiltException):
+                t4.Package().set_dir('foo', 's3://bucket/foo/')
+
+            # raises because of a '..' path separator
+            list_object_versions_mock.reset_mock()
+            list_object_versions_mock.return_value = ([
+                dict(Key='foo/../bar.txt', VersionId='null', IsLatest=True, Size=10),
+            ], [])
+            with pytest.raises(QuiltException):
+                t4.Package().set_dir('foo', 's3://bucket/foo/')
+
+            # raises because of a '.' object name
+            list_object_versions_mock.reset_mock()
+            list_object_versions_mock.return_value = ([
+                dict(Key='foo/.', VersionId='null', IsLatest=True, Size=10),
+            ], [])
+            with pytest.raises(QuiltException):
+                t4.Package().set_dir('foo', 's3://bucket/foo/')
+
+            # raises because of a '..' object name
+            list_object_versions_mock.reset_mock()
+            list_object_versions_mock.return_value = ([
+                dict(Key='foo/..', VersionId='null', IsLatest=True, Size=10),
+            ], [])
+            with pytest.raises(QuiltException):
+                t4.Package().set_dir('foo', 's3://bucket/foo/')
+
 
     def test_default_package_get_local(self):
         foodir = pathlib.Path("foo_dir")


### PR DESCRIPTION
Objects with the name `.` or `..` create serious issues in our client because even though these are legal S3 object names, these names have special meaning on the local filesystem. It's not sanitary to use these as file names or folder names even inside of S3.

We currently allow creating such objects and working with such objects, but we need to stop doing so because they're a foot gun.

This PR prevents users from creating packages containing `.` or `..` paths. A follow-up PR will do the same for the bucket API.