### PR TITLE
Cut 0.1.4 release

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 def readme():
     readme_short = """


### PR DESCRIPTION
This is the final PyPi release in the `quiltdata/t4` repository and the final version of [the `t4` package on PyPi](https://pypi.org/project/t4/0.1.3/#history). As of yesterday, all development activity on this project has shifted to `quiltdata/quilt`. Future releases can be found [in the version history there](https://github.com/quiltdata/quilt/releases).

This version of `t4`, `0.1.4`, corresponds with the `3.0.0` version of `quilt`.